### PR TITLE
Automatically set Berlin block in default chain config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,7 @@ var DefaultChainConfig = &ChainConfig{
 	ConstantinopleBlock: 0,
 	PetersburgBlock:     0,
 	IstanbulBlock:       0,
+	BerlinBlock:         0,
 }
 
 func (c *ChainConfig) Config() (*params.ChainConfig, error) {


### PR DESCRIPTION
Adds `berlin_block: 0` in chain config when performing `tenderly export init`