### PR TITLE
update truffle import directive paths

### DIFF
--- a/providers/deployment_provider.go
+++ b/providers/deployment_provider.go
@@ -140,6 +140,7 @@ type ContractNetwork struct {
 type Node struct {
 	NodeType     string `json:"nodeType"`
 	AbsolutePath string `json:"absolutePath"`
+	File         string `json:"file"`
 }
 
 type ContractAst struct {

--- a/truffle/contract.go
+++ b/truffle/contract.go
@@ -83,7 +83,7 @@ func (dp *DeploymentProvider) GetContracts(
 				absPath = strings.Replace(absPath, "\\", ":\\", 1)
 			}
 
-			if !sources[absPath] {
+			if !sources[absPath] && node.AbsolutePath == node.File {
 				sources[absPath] = false
 			}
 		}


### PR DESCRIPTION
# Elevator pitch

Currently, the way Tenderly parses import directives doesn't seem to work for Truffle. Imports of local files are also parsed as import directives with a placeholder token 'project:' instead of a global path, causing the later source parsing to fail. 

![image](https://user-images.githubusercontent.com/33545419/138688084-afa172e1-416e-49f3-84a0-3ba0db44f0f4.png)

[I have not tested this solution as I don't have Truffle/an adequate project yet]

This should resolve the issue outlined in [this](https://github.com/Tenderly/tenderly-cli/issues/43) thread.