### PR TITLE
Upgrade actions version to 0.0.6

### DIFF
--- a/commands/actions/init.go
+++ b/commands/actions/init.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	TypescriptActionsDependency        = "@tenderly/actions"
-	TypescriptActionsDependencyVersion = "^0.0.5"
+	TypescriptActionsDependencyVersion = "^0.0.6"
 	LanguageJavaScript                 = "javascript"
 	LanguageTypeScript                 = "typescript"
 )


### PR DESCRIPTION
## Description

The latest actions npm package version is `v0.0.6`. We should update the CLI to use the latest version and release the update.