### PR TITLE
refactor: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/brownie/config.go
+++ b/brownie/config.go
@@ -2,17 +2,17 @@ package brownie
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/tenderly/tenderly-cli/config"
 	"github.com/tenderly/tenderly-cli/providers"
 	"github.com/tenderly/tenderly-cli/userError"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 )
 
 type BrownieCompilerSettings struct {
@@ -35,7 +35,7 @@ func (dp *DeploymentProvider) GetConfig(configName string, projectDir string) (*
 		browniePath = strings.ReplaceAll(browniePath, `\`, `\\`)
 	}
 
-	data, err := ioutil.ReadFile(browniePath)
+	data, err := os.ReadFile(browniePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "read brownie config")
 	}

--- a/brownie/contract.go
+++ b/brownie/contract.go
@@ -3,15 +3,15 @@ package brownie
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/tenderly/tenderly-cli/model"
 	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -28,7 +28,7 @@ func (dp *DeploymentProvider) GetContracts(
 	objects ...*model.StateObject,
 ) ([]providers.Contract, int, error) {
 	contractsPath := filepath.Join(buildDir, BrownieContractDirectoryPath)
-	files, err := ioutil.ReadDir(contractsPath)
+	files, err := os.ReadDir(contractsPath)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "failed listing build files")
 	}
@@ -61,7 +61,7 @@ func (dp *DeploymentProvider) GetContracts(
 			continue
 		}
 		contractFilePath := filepath.Join(contractsPath, contractFile.Name())
-		data, err := ioutil.ReadFile(contractFilePath)
+		data, err := os.ReadFile(contractFilePath)
 		if err != nil {
 			logrus.Debug(fmt.Sprintf("Failed reading build file at %s with error: %s", contractFilePath, err))
 			break
@@ -79,7 +79,7 @@ func (dp *DeploymentProvider) GetContracts(
 
 	deploymentMapFile := filepath.Join(buildDir, BrownieContractDeploymentPath, BrownieContractMapFile)
 
-	data, err := ioutil.ReadFile(deploymentMapFile)
+	data, err := os.ReadFile(deploymentMapFile)
 	if err != nil {
 		logrus.Debug(fmt.Sprintf("Failed reading map file at %s with error: %s", deploymentMapFile, err))
 		return nil, 0, errors.Wrap(err, "failed reading map file")
@@ -127,7 +127,7 @@ func (dp *DeploymentProvider) resolveDependencies(path string, contractMap map[s
 		return errors.Wrap(err, "failed reading dependency files")
 	}
 	if info.IsDir() {
-		files, err := ioutil.ReadDir(path)
+		files, err := os.ReadDir(path)
 		if err != nil {
 			logrus.Debugf("Failed reading dependency at %s", path)
 			return errors.Wrap(err, "failed reading dependency files")
@@ -143,7 +143,7 @@ func (dp *DeploymentProvider) resolveDependencies(path string, contractMap map[s
 		return nil
 	}
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		logrus.Debug(fmt.Sprintf("Failed reading build file at %s with error: %s", path, err))
 		return errors.Wrap(err, "failed reading contract")

--- a/buidler/contract.go
+++ b/buidler/contract.go
@@ -3,16 +3,16 @@ package buidler
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/pkg/errors"
-	"github.com/tenderly/tenderly-cli/model"
-	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
+	"github.com/tenderly/tenderly-cli/model"
+	"github.com/tenderly/tenderly-cli/providers"
 )
 
 type BuidlerContract struct {
@@ -36,7 +36,7 @@ func (dp *DeploymentProvider) GetContracts(
 	networkIDs []string,
 	objects ...*model.StateObject,
 ) ([]providers.Contract, int, error) {
-	files, err := ioutil.ReadDir(buildDir)
+	files, err := os.ReadDir(buildDir)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "failed listing build files")
 	}
@@ -63,14 +63,14 @@ func (dp *DeploymentProvider) GetContracts(
 			continue
 		}
 		filePath := filepath.Join(buildDir, file.Name())
-		contractFiles, err := ioutil.ReadDir(filePath)
+		contractFiles, err := os.ReadDir(filePath)
 
 		for _, contractFile := range contractFiles {
 			if contractFile.IsDir() || !strings.HasSuffix(contractFile.Name(), ".json") {
 				continue
 			}
 			contractFilePath := filepath.Join(filePath, contractFile.Name())
-			data, err := ioutil.ReadFile(contractFilePath)
+			data, err := os.ReadFile(contractFilePath)
 
 			if err != nil {
 				return nil, 0, errors.Wrap(err, "failed reading build file")
@@ -195,7 +195,7 @@ func (dp *DeploymentProvider) GetContracts(
 					}
 				}
 
-				source, err := ioutil.ReadFile(localPath)
+				source, err := os.ReadFile(localPath)
 				if err != nil {
 					return nil, 0, errors.Wrap(err, "failed reading contract source file")
 				}

--- a/buidler/source.go
+++ b/buidler/source.go
@@ -3,12 +3,12 @@ package buidler
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/tenderly/tenderly-cli/ethereum"
+	"github.com/tenderly/tenderly-cli/providers"
 	"github.com/tenderly/tenderly-cli/stacktrace"
 )
 
@@ -29,7 +29,7 @@ func (dp *DeploymentProvider) NewContractSource(path string, networkId string, c
 
 func (dp *DeploymentProvider) loadBuidlerContracts(path string) ([]*providers.Contract, error) {
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed listing buidler build files: %s", err)
 	}
@@ -40,7 +40,7 @@ func (dp *DeploymentProvider) loadBuidlerContracts(path string) ([]*providers.Co
 			continue
 		}
 
-		data, err := ioutil.ReadFile(filepath.Join(path, file.Name()))
+		data, err := os.ReadFile(filepath.Join(path, file.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("failed reading buidler build files: %s", err)
 		}

--- a/commands/check_updates.go
+++ b/commands/check_updates.go
@@ -2,10 +2,7 @@ package commands
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/tenderly/tenderly-cli/userError"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"os"
@@ -15,7 +12,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/tenderly/tenderly-cli/userError"
 )
 
 type releaseResult struct {
@@ -85,7 +85,7 @@ func CheckVersion(force bool, encounteredError bool) {
 
 	defer response.Body.Close()
 
-	contents, err := ioutil.ReadAll(response.Body)
+	contents, err := io.ReadAll(response.Body)
 	if err != nil {
 		if force && !encounteredError {
 			userError.LogErrorf("failed reading github releases request: %s", userError.NewUserError(
@@ -246,7 +246,7 @@ func getCliMessage(release releaseResult) (string, error) {
 
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", errors.Wrap(err, "read cli-message.json")
 	}

--- a/commands/util/filesystem.go
+++ b/commands/util/filesystem.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -87,7 +86,7 @@ func ReadFile(path string) string {
 				fmt.Sprintf("Couldn't read file at %s. File does not exist.", path)))
 		os.Exit(1)
 	}
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		userError.LogErrorf(
 			"failed to read file: %s",
@@ -110,7 +109,7 @@ func CreateFileWithContent(path string, content string) {
 				fmt.Sprintf("Couldn't create file at %s. File already exists.", path)))
 		os.Exit(1)
 	}
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		path,
 		[]byte(content),
 		os.FileMode(0755),

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"os/user"
@@ -418,7 +417,7 @@ func WriteGlobalConfig() error {
 
 // ReadProjectConfig is necessary because viper reader doesn't respect custom unmarshaler
 func ReadProjectConfig() ([]byte, error) {
-	return ioutil.ReadFile(filepath.Join(ProjectDirectory, fmt.Sprintf("%s.yaml", ProjectConfigName)))
+	return os.ReadFile(filepath.Join(ProjectDirectory, fmt.Sprintf("%s.yaml", ProjectConfigName)))
 }
 
 func getString(key string) string {

--- a/hardhat/contract.go
+++ b/hardhat/contract.go
@@ -3,17 +3,17 @@ package hardhat
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/tenderly/tenderly-cli/model"
-	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/tenderly/tenderly-cli/model"
+	"github.com/tenderly/tenderly-cli/providers"
 )
 
 type HardhatContract struct {
@@ -37,7 +37,7 @@ func (dp *DeploymentProvider) GetContracts(
 	networkIDs []string,
 	objects ...*model.StateObject,
 ) ([]providers.Contract, int, error) {
-	files, err := ioutil.ReadDir(buildDir)
+	files, err := os.ReadDir(buildDir)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "failed listing build files")
 	}
@@ -64,7 +64,7 @@ func (dp *DeploymentProvider) GetContracts(
 			continue
 		}
 		filePath := filepath.Join(buildDir, file.Name())
-		contractFiles, _ := ioutil.ReadDir(filePath)
+		contractFiles, _ := os.ReadDir(filePath)
 
 		successfulRead := true
 		for _, contractFile := range contractFiles {
@@ -72,7 +72,7 @@ func (dp *DeploymentProvider) GetContracts(
 				continue
 			}
 			contractFilePath := filepath.Join(filePath, contractFile.Name())
-			data, err := ioutil.ReadFile(contractFilePath)
+			data, err := os.ReadFile(contractFilePath)
 
 			if err != nil {
 				logrus.Debug(fmt.Sprintf("Failed reading build file at %s with error: %s", contractFilePath, err))
@@ -126,7 +126,7 @@ func (dp *DeploymentProvider) GetContracts(
 				} else {
 					chainIdPath := filepath.Join(filePath, ".chainId")
 
-					chainData, err := ioutil.ReadFile(chainIdPath)
+					chainData, err := os.ReadFile(chainIdPath)
 					if err != nil {
 						logrus.Debug(fmt.Sprintf("Failed reading chainID file at %s with error: %s", chainIdPath, err))
 						successfulRead = false
@@ -236,7 +236,7 @@ func (dp *DeploymentProvider) GetContracts(
 					}
 				}
 
-				source, err := ioutil.ReadFile(localPath)
+				source, err := os.ReadFile(localPath)
 				if err != nil {
 					localPath = filepath.Join("node_modules", currentLocalPath)
 					doesNotExist := providers.CheckIfFileDoesNotExist(localPath)
@@ -244,7 +244,7 @@ func (dp *DeploymentProvider) GetContracts(
 						localPath = providers.GetGlobalPathForModule(currentLocalPath)
 					}
 
-					source, err := ioutil.ReadFile(localPath)
+					source, err := os.ReadFile(localPath)
 					if err != nil {
 						logrus.Debug(fmt.Sprintf("Failed reading contract source file at %s with error: %s", localPath, err))
 						successfulRead = false

--- a/hardhat/source.go
+++ b/hardhat/source.go
@@ -3,12 +3,12 @@ package hardhat
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/tenderly/tenderly-cli/ethereum"
+	"github.com/tenderly/tenderly-cli/providers"
 	"github.com/tenderly/tenderly-cli/stacktrace"
 )
 
@@ -29,7 +29,7 @@ func (dp *DeploymentProvider) NewContractSource(path string, networkId string, c
 
 func (dp *DeploymentProvider) loadHardhatContracts(path string) ([]*providers.Contract, error) {
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed listing hardhat build files: %s", err)
 	}
@@ -40,7 +40,7 @@ func (dp *DeploymentProvider) loadHardhatContracts(path string) ([]*providers.Co
 			continue
 		}
 
-		data, err := ioutil.ReadFile(filepath.Join(path, file.Name()))
+		data, err := os.ReadFile(filepath.Join(path, file.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("failed reading hardhat build files: %s", err)
 		}

--- a/jsonrpc2/http.go
+++ b/jsonrpc2/http.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sync"
 )
@@ -63,7 +62,7 @@ func (conn *httpConnection) Write(msg *Request) error {
 		return fmt.Errorf("write request body: %s", err)
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(data))
+	req.Body = io.NopCloser(bytes.NewReader(data))
 	req.ContentLength = int64(len(data))
 
 	resp, err := http.DefaultClient.Do(req)

--- a/model/actions/template.go
+++ b/model/actions/template.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ func (t *Template) Create(ctx context.Context, destinationDir string, args map[s
 		}
 
 		destinationPath := filepath.Join(destinationDir, file)
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			destinationPath,
 			[]byte(content),
 			os.FileMode(0755),

--- a/model/actions/util_test.go
+++ b/model/actions/util_test.go
@@ -2,7 +2,7 @@ package actions_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strings"
 
@@ -14,7 +14,7 @@ import (
 func MustReadTest(filename string) []byte {
 	_, thisFilename, _, _ := runtime.Caller(0)
 	path := strings.TrimSuffix(thisFilename, "util_test.go") + fmt.Sprintf("yaml/%s.yaml", filename)
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		panic(errors.Wrap(err, fmt.Sprintf("read test case %s", filename)))
 	}

--- a/openzeppelin/config.go
+++ b/openzeppelin/config.go
@@ -3,17 +3,17 @@ package openzeppelin
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/tenderly/tenderly-cli/config"
-	"github.com/tenderly/tenderly-cli/providers"
-	"github.com/tenderly/tenderly-cli/userError"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tenderly/tenderly-cli/config"
+	"github.com/tenderly/tenderly-cli/providers"
+	"github.com/tenderly/tenderly-cli/userError"
 )
 
 func (dp *DeploymentProvider) GetConfig(configName string, projectDir string) (*providers.Config, error) {
@@ -86,7 +86,7 @@ func (dp *DeploymentProvider) GetConfig(configName string, projectDir string) (*
 		return nil, fmt.Errorf("cannot find project.json, tried path: %s, error: %s", openzeppelinProjectPath, err)
 	}
 
-	data, err = ioutil.ReadFile(openzeppelinProjectPath)
+	data, err = os.ReadFile(openzeppelinProjectPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read project.json, tried path: %s, error: %s", openzeppelinProjectPath, err)
 	}

--- a/openzeppelin/contract.go
+++ b/openzeppelin/contract.go
@@ -2,15 +2,15 @@ package openzeppelin
 
 import (
 	"encoding/json"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/pkg/errors"
-	"github.com/tenderly/tenderly-cli/model"
-	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
+	"github.com/tenderly/tenderly-cli/model"
+	"github.com/tenderly/tenderly-cli/providers"
 )
 
 func (dp *DeploymentProvider) GetContracts(
@@ -18,7 +18,7 @@ func (dp *DeploymentProvider) GetContracts(
 	networkIDs []string,
 	objects ...*model.StateObject,
 ) ([]providers.Contract, int, error) {
-	files, err := ioutil.ReadDir(buildDir)
+	files, err := os.ReadDir(buildDir)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "failed listing build files")
 	}
@@ -46,7 +46,7 @@ func (dp *DeploymentProvider) GetContracts(
 		}
 
 		filePath := filepath.Join(buildDir, file.Name())
-		data, err := ioutil.ReadFile(filePath)
+		data, err := os.ReadFile(filePath)
 
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "failed reading build file")
@@ -128,7 +128,7 @@ func (dp *DeploymentProvider) GetContracts(
 				}
 			}
 
-			source, err := ioutil.ReadFile(localPath)
+			source, err := os.ReadFile(localPath)
 			if err != nil {
 				return nil, 0, errors.Wrap(err, "failed reading contract source file")
 			}

--- a/openzeppelin/source.go
+++ b/openzeppelin/source.go
@@ -3,12 +3,12 @@ package openzeppelin
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/tenderly/tenderly-cli/ethereum"
+	"github.com/tenderly/tenderly-cli/providers"
 	"github.com/tenderly/tenderly-cli/stacktrace"
 )
 
@@ -29,7 +29,7 @@ func (dp *DeploymentProvider) NewContractSource(path string, networkId string, c
 
 func (dp *DeploymentProvider) loadOpenZeppelinContracts(path string) ([]*providers.Contract, error) {
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed listing openzeppelin build files: %s", err)
 	}
@@ -40,7 +40,7 @@ func (dp *DeploymentProvider) loadOpenZeppelinContracts(path string) ([]*provide
 			continue
 		}
 
-		data, err := ioutil.ReadFile(filepath.Join(path, file.Name()))
+		data, err := os.ReadFile(filepath.Join(path, file.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("failed reading openzeppelin build files: %s", err)
 		}

--- a/rest/call/project.go
+++ b/rest/call/project.go
@@ -3,11 +3,12 @@ package call
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/tenderly/tenderly-cli/config"
 	"github.com/tenderly/tenderly-cli/model"
 	"github.com/tenderly/tenderly-cli/rest/client"
 	"github.com/tenderly/tenderly-cli/rest/payloads"
-	"io/ioutil"
 )
 
 type ProjectCalls struct {
@@ -59,7 +60,7 @@ func (rest *ProjectCalls) GetProjects(accountId string) (*payloads.GetProjectsRe
 		nil,
 	)
 
-	data, err := ioutil.ReadAll(response)
+	data, err := io.ReadAll(response)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -5,14 +5,14 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+
 	"github.com/sirupsen/logrus"
 	"github.com/tenderly/tenderly-cli/config"
 	"github.com/tenderly/tenderly-cli/rest/payloads"
 	"github.com/tenderly/tenderly-cli/userError"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"os"
 )
 
 const sessionLimitErrorSlug = "session_limit_exceeded"
@@ -123,7 +123,7 @@ func Request(method, path string, body []byte) io.Reader {
 		os.Exit(1)
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	defer res.Body.Close()
 
 	if err != nil {

--- a/truffle/contract.go
+++ b/truffle/contract.go
@@ -2,15 +2,15 @@ package truffle
 
 import (
 	"encoding/json"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/pkg/errors"
-	"github.com/tenderly/tenderly-cli/model"
-	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
+	"github.com/tenderly/tenderly-cli/model"
+	"github.com/tenderly/tenderly-cli/providers"
 )
 
 func (dp *DeploymentProvider) GetContracts(
@@ -18,7 +18,7 @@ func (dp *DeploymentProvider) GetContracts(
 	networkIDs []string,
 	objects ...*model.StateObject,
 ) ([]providers.Contract, int, error) {
-	files, err := ioutil.ReadDir(buildDir)
+	files, err := os.ReadDir(buildDir)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "failed listing build files")
 	}
@@ -46,7 +46,7 @@ func (dp *DeploymentProvider) GetContracts(
 		}
 
 		filePath := filepath.Join(buildDir, file.Name())
-		data, err := ioutil.ReadFile(filePath)
+		data, err := os.ReadFile(filePath)
 
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "failed reading build file")
@@ -128,7 +128,7 @@ func (dp *DeploymentProvider) GetContracts(
 				}
 			}
 
-			source, err := ioutil.ReadFile(localPath)
+			source, err := os.ReadFile(localPath)
 			if err != nil {
 				return nil, 0, errors.Wrap(err, "failed reading contract source file")
 			}

--- a/truffle/source.go
+++ b/truffle/source.go
@@ -3,12 +3,12 @@ package truffle
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/tenderly/tenderly-cli/providers"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/tenderly/tenderly-cli/ethereum"
+	"github.com/tenderly/tenderly-cli/providers"
 	"github.com/tenderly/tenderly-cli/stacktrace"
 )
 
@@ -29,7 +29,7 @@ func (dp *DeploymentProvider) NewContractSource(path string, networkId string, c
 
 func (dp *DeploymentProvider) loadTruffleContracts(path string) ([]*providers.Contract, error) {
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed listing truffle build files: %s", err)
 	}
@@ -40,7 +40,7 @@ func (dp *DeploymentProvider) loadTruffleContracts(path string) ([]*providers.Co
 			continue
 		}
 
-		data, err := ioutil.ReadFile(filepath.Join(path, file.Name()))
+		data, err := os.ReadFile(filepath.Join(path, file.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("failed reading truffle build files: %s", err)
 		}

--- a/typescript/package.go
+++ b/typescript/package.go
@@ -2,7 +2,6 @@ package typescript
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -29,7 +28,7 @@ func DefaultPackageJson(name string) *PackageJson {
 func LoadPackageJson(directory string) (*PackageJson, error) {
 	path := filepath.Join(directory, PackageJsonFile)
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "read package.json")
 	}
@@ -51,7 +50,7 @@ func SavePackageJson(directory string, config *PackageJson) error {
 
 	// os.FileMode(0755) The owner can read, write, execute.
 	// Everyone else can read and execute but not modify the file.
-	err = ioutil.WriteFile(filepath.Join(directory, PackageJsonFile), packageJSON, os.FileMode(0755))
+	err = os.WriteFile(filepath.Join(directory, PackageJsonFile), packageJSON, os.FileMode(0755))
 	if err != nil {
 		return errors.Wrap(err, "failed to save package.json")
 	}

--- a/typescript/tsconfig.go
+++ b/typescript/tsconfig.go
@@ -2,7 +2,6 @@ package typescript
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -55,7 +54,7 @@ func DefaultTsConfig() *TsConfig {
 func LoadTsConfig(directory string) (*TsConfig, error) {
 	path := filepath.Join(directory, TsConfigFile)
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "read tsconfig")
 	}
@@ -145,7 +144,7 @@ func SaveTsConfig(directory string, config *TsConfig) error {
 
 	// os.FileMode(0755) The owner can read, write, execute.
 	// Everyone else can read and execute but not modify the file.
-	err = ioutil.WriteFile(filepath.Join(directory, TsConfigFile), tsconfig, os.FileMode(0755))
+	err = os.WriteFile(filepath.Join(directory, TsConfigFile), tsconfig, os.FileMode(0755))
 	if err != nil {
 		return errors.Wrap(err, "failed to save tsconfig")
 	}

--- a/zip/zip.go
+++ b/zip/zip.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -30,7 +30,7 @@ func Zip(dirPath string, insidePath string) ([]string, []byte, error) {
 			return errors.Wrap(err, fmt.Sprintf("failed to read path %s", path))
 		}
 
-		dat, err := ioutil.ReadFile(path)
+		dat, err := os.ReadFile(path)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed reading %s", path))
 		}


### PR DESCRIPTION
`os.ReadDir` was added in Go 1.16 as part of the deprecation of `ioutil` package. It is a more efficient implementation than `ioutil.ReadDir` as stated here https://pkg.go.dev/io/ioutil#ReadDir . The full proposal can be read here https://<!---->github.com<!---->/<!---->golang<!---->/go/issues/41467

This PR also replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages, since the `io/ioutil` package has been deprecated as of Go 1.16, see https://golang.org/doc/go1.16#ioutil.