### PR TITLE
Adding validator for packages in `package.json`.

### DIFF
--- a/commands/actions/publish.go
+++ b/commands/actions/publish.go
@@ -479,7 +479,7 @@ func mustExistCompiledFiles(outDir string, actions *actionsModel.ProjectActions)
 	}
 }
 
-func printPackageValidationErrors(vE []*packagejson.ValidationError) {
+func printPackageValidationErrors(validationErrors []*packagejson.ValidationError) {
 	logrus.Error("The following packages have invalid versions:")
 	for _, e := range vE {
 		logrus.Error(commands.Colorizer.Sprintf(

--- a/commands/actions/publish.go
+++ b/commands/actions/publish.go
@@ -481,7 +481,7 @@ func mustExistCompiledFiles(outDir string, actions *actionsModel.ProjectActions)
 
 func printPackageValidationErrors(validationErrors []*packagejson.ValidationError) {
 	logrus.Error("The following packages have invalid versions:")
-	for _, e := range vE {
+	for _, e := range validationErrors {
 		logrus.Error(commands.Colorizer.Sprintf(
 			"  %s\n\tFound: %s\n\tRequired: %s",
 			commands.Colorizer.Bold(commands.Colorizer.Bold(e.Name)),

--- a/commands/util/packagejson/constraints.go
+++ b/commands/util/packagejson/constraints.go
@@ -20,6 +20,7 @@ func (dc Constraints) findConstraints(dependencyName string) (version.Constraint
 
 var runtimesToConstraints = map[string]*Constraints{
 	"V1": {
-		"axios": "<1.0.0",
+		"axios":             "<1.0.0",
+		"@tenderly/actions": "<0.1.0",
 	},
 }

--- a/commands/util/packagejson/constraints.go
+++ b/commands/util/packagejson/constraints.go
@@ -1,0 +1,25 @@
+package packagejson
+
+import "github.com/hashicorp/go-version"
+
+type Constraints map[string]string
+
+func (dc Constraints) findConstraints(dependencyName string) (version.Constraints, error) {
+	constraintString, ok := dc[dependencyName]
+	if !ok {
+		return nil, nil
+	}
+
+	constraints, err := version.NewConstraint(constraintString)
+	if err != nil {
+		return nil, err
+	}
+
+	return constraints, nil
+}
+
+var runtimesToConstraints = map[string]*Constraints{
+	"V1": {
+		"axios": "<1.0.0",
+	},
+}

--- a/commands/util/packagejson/validator.go
+++ b/commands/util/packagejson/validator.go
@@ -126,7 +126,6 @@ func unmarshalVersion(message bytes.Buffer) (string, error) {
 		return v, nil
 	case '[':
 		var versions []string
-		message = *bytes.NewBufferString("aha")
 		err = json.Unmarshal(rawMessage, &versions)
 		if err != nil {
 			return "", userError.NewUserError(err, "error unmarshalling response from npm")

--- a/commands/util/packagejson/validator.go
+++ b/commands/util/packagejson/validator.go
@@ -1,0 +1,141 @@
+package packagejson
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
+	"github.com/tenderly/tenderly-cli/userError"
+)
+
+type Validator struct {
+	constraints *Constraints
+}
+
+func NewValidator(runtimeName string) *Validator {
+	constraints := runtimesToConstraints[strings.ToUpper(runtimeName)]
+	if constraints == nil {
+		return &Validator{
+			constraints: &Constraints{},
+		}
+	}
+
+	return &Validator{
+		constraints: constraints,
+	}
+}
+
+type ValidationError struct {
+	Name                 string
+	PackageJsonVersion   string
+	Constraint           string
+	VersionToBeInstalled string
+}
+
+type ValidationResult struct {
+	Success bool
+	Errors  []*ValidationError
+}
+
+func (dv *Validator) Validate(dependencies map[string]string) (*ValidationResult, error) {
+	var validationErrors []*ValidationError
+
+	for packageName, packageVersion := range dependencies {
+		constraint, err := dv.constraints.findConstraints(packageName)
+		if err != nil {
+			return nil, err
+		}
+
+		if constraint == nil {
+			continue
+		}
+
+		versionToBeInstalled, err := FindPackageVersion(packageName, packageVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		parsedVersion, err := version.NewVersion(versionToBeInstalled)
+		if err != nil {
+			return nil, errors.New("error parsing version")
+		}
+
+		if !constraint.Check(parsedVersion) {
+			validationErrors = append(validationErrors, &ValidationError{
+				Name:                 packageName,
+				PackageJsonVersion:   packageVersion,
+				Constraint:           constraint.String(),
+				VersionToBeInstalled: versionToBeInstalled,
+			})
+		}
+	}
+
+	return &ValidationResult{
+		Success: len(validationErrors) == 0,
+		Errors:  validationErrors,
+	}, nil
+}
+
+func FindPackageVersion(name string, version string) (string, error) {
+	lookup := name + "@" + version
+
+	cmd := exec.Command("npm", "view", lookup, "version", "--json")
+	var out bytes.Buffer
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = &out
+
+	err := cmd.Start()
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("Failed to run: npm view %s version --json", lookup))
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("Failed to run: npm view %s version --json", lookup))
+	}
+
+	ver, err := unmarshalVersion(out)
+	if err != nil {
+		return "", err
+	}
+
+	return ver, nil
+}
+
+func unmarshalVersion(message bytes.Buffer) (string, error) {
+	var rawMessage json.RawMessage
+
+	err := json.Unmarshal(message.Bytes(), &rawMessage)
+	if err != nil {
+		return "", userError.NewUserError(err, "error unmarshalling response from npm")
+	}
+
+	switch rawMessage[0] {
+	case '"':
+		var v string
+		err = json.Unmarshal(rawMessage, &v)
+		if err != nil {
+			return "", userError.NewUserError(err, "error unmarshalling response from npm")
+		}
+
+		return v, nil
+	case '[':
+		var versions []string
+		message = *bytes.NewBufferString("aha")
+		err = json.Unmarshal(rawMessage, &versions)
+		if err != nil {
+			return "", userError.NewUserError(err, "error unmarshalling response from npm")
+		}
+
+		highestVersion := versions[len(versions)-1]
+		return highestVersion, nil
+	default:
+		err := errors.New(fmt.Sprintf("Unexpected response from npm: %s", rawMessage))
+		return "", userError.NewUserError(err, "error unmarshalling response from npm")
+	}
+}

--- a/commands/util/typescript.go
+++ b/commands/util/typescript.go
@@ -67,3 +67,7 @@ func MustLoadPackageJSON(directory string) *typescript.PackageJson {
 func PackageJSONExists(directory string) bool {
 	return ExistFile(filepath.Join(directory, typescript.PackageJsonFile))
 }
+
+func HasDependencies(packageJSON *typescript.PackageJson) bool {
+	return len(packageJSON.Dependencies)+len(packageJSON.DevDependencies) != 0
+}


### PR DESCRIPTION
# Description
This PR is adding validation for packages listed in `package.json` for actions. Specifically, it ensures that versions of packages stated in `package.json` comply with constraints specified for different versions of web3 action runtimes.

The validation occurs during the `build` phase, before the `publish`/`deploy` phase.

Two new files are being added to introduce the validation:
- `commands/util/packagejson/constraints.go`, containing the mapping between constraints and runtimes;
- `commands/util/packagejson/validator.go`, containing the validator logic.

The validator itself uses `npm view` command to fetch versions from the npm registry.