### PR TITLE
Add route to rename contract

### DIFF
--- a/rest/call/contract.go
+++ b/rest/call/contract.go
@@ -101,3 +101,27 @@ func (rest *ContractCalls) RemoveContracts(request payloads.RemoveContractsReque
 
 	return &res, err
 }
+
+func (rest *ContractCalls) RenameContract(
+	request payloads.RenameContractRequest,
+	projectSlug, networkID, address string,
+) (*payloads.RenameContractResponse, error) {
+	renameJson, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	response := client.Request(
+		"POST",
+		fmt.Sprintf("api/v1/account/me/project/%s/contract/%s/%s/rename", projectSlug, networkID, address),
+		renameJson,
+	)
+
+	var res payloads.RenameContractResponse
+	err = json.NewDecoder(response).Decode(&res)
+	if err.Error() == "EOF" {
+		return nil, nil
+	}
+
+	return &res, err
+}

--- a/rest/payloads/contractPayloads.go
+++ b/rest/payloads/contractPayloads.go
@@ -28,6 +28,14 @@ type RemoveContractsResponse struct {
 	Error *ApiError `json:"error"`
 }
 
+type RenameContractRequest struct {
+	DisplayName string `json:"display_name"`
+}
+
+type RenameContractResponse struct {
+	Error *ApiError `json:"error"`
+}
+
 type Config struct {
 	OptimizationsUsed  *bool          `json:"optimizations_used,omitempty"`
 	OptimizationsCount *int           `json:"optimizations_count,omitempty"`

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -27,6 +27,7 @@ type ContractRoutes interface {
 	UploadContracts(request payloads.UploadContractsRequest, projectSlug string) (*payloads.UploadContractsResponse, error)
 	VerifyContracts(request payloads.UploadContractsRequest) (*payloads.UploadContractsResponse, error)
 	RemoveContracts(request payloads.RemoveContractsRequest, projectSlug string) (*payloads.RemoveContractsResponse, error)
+	RenameContract(request payloads.RenameContractRequest, projectSlug, networkID, address string) (*payloads.RenameContractResponse, error)
 }
 
 type ExportRoutes interface {


### PR DESCRIPTION
# Description<br>

This PR adds a method `RenameContract` to `rest.ContractRoute`, allowing to change the displayed name of a contract.

It bases on the following request specs

```
curl -X POST "https://api.tenderly.co/api/v1/account/me/project/${PROJECT_SLUG}/contract/${NETWORK_ID}/${CONTRACT_ADDRESS}/rename --header "Content-Type: application/json" --header 'X-Access-Key: ${access_key}' --data-raw '{"display_name":"New Name"}'
```