### PR TITLE
Resolve  "Couldn't read Hardhat config file"

### DIFF
--- a/hardhat/config.go
+++ b/hardhat/config.go
@@ -79,6 +79,9 @@ func (dp *DeploymentProvider) GetConfig(configName string, projectDir string) (*
 				// Store value in our collection
 				cache.push(value);
 			}
+			if (typeof value === 'bigint') {
+				value = value.toString();
+			}
 			return value;
 		}, '');
 		


### PR DESCRIPTION
This PR fixes an issue where Tenderly throws `Couldn't read Hardhat config file` when attempting to use `tenderly export` against newer Hardhat versions.

The underlying error is: `TypeError: Do not know how to serialize a BigInt`. Hardhat now uses BigInts in its config, which are not serializable, so we must convert them to strings during the `JSON.stringify` call.

This is likely the cause of the failure seen in https://github.com/Tenderly/tenderly-cli/issues/110

