### PR TITLE
Update instruction for verify command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ exports: # running tenderly export will export local transaction to the provided
 The `verify` command uploads your smart contracts and verifies them on [Tenderly](https://tenderly.co).
 
 ```
-tenderly verify
+tenderly contracts verify
 ```
 
 #### Command Flags


### PR DESCRIPTION
```
❯ tenderly verify
Command "verify" is deprecated, Use "tenderly contracts verify"
```