### PR TITLE
Adding `walkSymlink` function to support walking symlinks when zipping dirs.

### DIFF
--- a/zip/zip.go
+++ b/zip/zip.go
@@ -19,10 +19,20 @@ func Zip(dirPath string, insidePath string) ([]string, []byte, error) {
 	var files []string
 
 	err := filepath.WalkDir(dirPath, func(path string, dirEntry os.DirEntry, err error) error {
+		destPath := getDestPath(path, dirPath, insidePath)
+
 		if dirEntry == nil {
 			return fmt.Errorf("directory missing %s", dirPath)
 		}
 		if dirEntry.IsDir() {
+			return nil
+		}
+		if dirEntry.Type() == os.ModeSymlink {
+			err := walkSymlink(writer, &files, path, destPath)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("failed to walk symlinked dir %s", dirPath))
+			}
+
 			return nil
 		}
 		if err != nil {
@@ -34,8 +44,6 @@ func Zip(dirPath string, insidePath string) ([]string, []byte, error) {
 			return errors.Wrap(err, fmt.Sprintf("failed reading %s", path))
 		}
 
-		relativePath := strings.TrimPrefix(path, dirPath)
-		destPath := filepath.Join(insidePath, relativePath)
 		destFile, err := writer.Create(destPath)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed creating %s", destPath))
@@ -58,4 +66,54 @@ func Zip(dirPath string, insidePath string) ([]string, []byte, error) {
 	}
 
 	return files, buf.Bytes(), nil
+}
+
+func walkSymlink(writer *zip.Writer, files *[]string, path string, destBasePath string) error {
+	evaluatedDirPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to eval symlink %s", path))
+	}
+
+	return filepath.WalkDir(evaluatedDirPath, func(path string, dirEntry os.DirEntry, err error) error {
+		if dirEntry == nil {
+			return fmt.Errorf("directory missing %s", evaluatedDirPath)
+		}
+		if dirEntry.IsDir() {
+			return nil
+		}
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to read path %s", path))
+		}
+
+		dat, err := os.ReadFile(path)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed reading %s", path))
+		}
+
+		destPath := getDestPath(path, evaluatedDirPath, destBasePath)
+		destFile, err := writer.Create(destPath)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed creating %s", destPath))
+		}
+		_, err = destFile.Write(dat)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed writing %s", destPath))
+		}
+		*files = append(*files, path)
+
+		return nil
+	})
+}
+
+/*
+Provides path that filePath will have in the output zip.
+filePath - Represents full path to the file (e.g. `node_modules/x/y.js`
+dirPath - Represents path to the directory which contains the file (e.g. `node_modules/x/`)
+destBasePath - Represents desired base path that the file will have in output zip (e.g. `nodejs/node_modules/x`)
+
+For the example above, the output will be `nodejs/node_modules/x/y.js`.
+*/
+func getDestPath(filePath string, dirPath string, destBasePath string) string {
+	relativePath := strings.TrimPrefix(filePath, dirPath)
+	return filepath.Join(destBasePath, relativePath)
 }


### PR DESCRIPTION
# Context
Our Zip function in `zip/zip.go:Zip` relies on https://pkg.go.dev/path/filepath#WalkDir which doesn't follow symlinks.
This causes issues with monorepos where local dependencies are symlinked in `node_modules`.
Since the symlink cannot be resolved, the build process fails during zip creation.
 
# What is this PR solving
This PR is meant to enable our `zip/zip.go:Zip` function to follow symlinks, properly resolve them and add the files in the symlinked dirs to the output zip.

# How is this PR solving it
It is adding a new method `walkSymlink(writer *zip.Writer, files *[]string, path string, destBasePath string) error` which firs evaluates symlinked dir passed as the `path` argument and then continues with the resolved dir in the same way as the `filepath.WalkDir` function behaved in our `Zip` function.