### PR TITLE
add support for spawn-rpc api

### DIFF
--- a/buidler/buidler.go
+++ b/buidler/buidler.go
@@ -22,6 +22,7 @@ func NewDeploymentProvider() *DeploymentProvider {
 		call.NewExportCalls(),
 		call.NewNetworkCalls(),
 		call.NewActionCalls(),
+		call.NewDevNetCalls(),
 	)
 
 	networks, err := rest.Networks.GetPublicNetworks()

--- a/commands/devnet/devnet.go
+++ b/commands/devnet/devnet.go
@@ -6,10 +6,10 @@ import (
 )
 
 func init() {
-	commands.RootCmd.AddCommand(DevNetCmd)
+	commands.RootCmd.AddCommand(CmdDevNet)
 }
 
-var DevNetCmd = &cobra.Command{
+var CmdDevNet = &cobra.Command{
 	Use:   "devnet",
 	Short: "Tenderly DevNets.",
 }

--- a/commands/devnet/devnet.go
+++ b/commands/devnet/devnet.go
@@ -1,0 +1,15 @@
+package devnet
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tenderly/tenderly-cli/commands"
+)
+
+func init() {
+	commands.RootCmd.AddCommand(DevNetCmd)
+}
+
+var DevNetCmd = &cobra.Command{
+	Use:   "devnet",
+	Short: "Tenderly DevNets.",
+}

--- a/commands/devnet/spawn_rpc.go
+++ b/commands/devnet/spawn_rpc.go
@@ -1,0 +1,109 @@
+package devnet
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/tenderly/tenderly-cli/commands"
+	"github.com/tenderly/tenderly-cli/config"
+	"github.com/tenderly/tenderly-cli/userError"
+	"os"
+)
+
+var accountID string
+var projectSlug string
+var templateSlug string
+var accessKey string
+var token string
+
+func init() {
+	spawnRpcCommand.PersistentFlags().StringVar(
+		&accountID,
+		"account",
+		"",
+		"The Tenderly account. If not provided, the system will try to read 'account_id' from the 'tenderly.yaml' configuration file.",
+	)
+	spawnRpcCommand.PersistentFlags().StringVar(
+		&projectSlug,
+		"project",
+		"",
+		"The DevNet project slug. If not provided, the system will try to read 'project_slug' from the 'tenderly.yaml' configuration file.",
+	)
+	spawnRpcCommand.PersistentFlags().StringVar(
+		&templateSlug,
+		"template",
+		"",
+		"The DevNet template which is going to be applied when spawning the DevNet RPC.",
+	)
+	spawnRpcCommand.PersistentFlags().StringVar(
+		&accessKey,
+		"access_key",
+		"",
+		"The Tenderly access key. If not provided, the system will try to read 'access_key' from the 'tenderly.yaml' configuration file.",
+	)
+	spawnRpcCommand.PersistentFlags().StringVar(
+		&token,
+		"token",
+		"",
+		"The Tenderly token. If not provided, the system will try to read 'token' from the 'tenderly.yaml' configuration file.",
+	)
+	commands.RootCmd.AddCommand(spawnRpcCommand)
+}
+
+var spawnRpcCommand = &cobra.Command{
+	Use:   "spawn-rpc",
+	Short: "Spawn DevNet RPC",
+	Long:  `Spawn DevNet RPC that represents the network endpoint for your DevNet`,
+	Run:   spawnRPCHandler,
+}
+
+func spawnRPCHandler(cmd *cobra.Command, args []string) {
+	if accountID == "" {
+		commands.CheckLogin()
+		accountID = config.GetGlobalString(config.AccountID)
+	}
+
+	if accountID == "" {
+		err := userError.NewUserError(errors.New("account not found"), "No account found. Please login with `tenderly login` or provide '--account' flag")
+		userError.LogError(err)
+		os.Exit(1)
+	}
+
+	if accessKey == "" {
+		accessKey = config.GetGlobalString(config.AccessKey)
+	}
+
+	if token == "" {
+		token = config.GetGlobalString(config.Token)
+	}
+
+	if accessKey == "" && token == "" {
+		err := userError.NewUserError(errors.New("access key or token not found"), "No access key or token found. Please login with `tenderly login` or provide '--access_key' or '--token' flag")
+		userError.LogError(err)
+		os.Exit(1)
+	}
+
+	if projectSlug == "" {
+		projectSlug = config.MaybeGetString(config.ProjectSlug)
+	}
+
+	if projectSlug == "" {
+		err := userError.NewUserError(errors.New("project not found"), "No project found. Please set a project with `tenderly use project <project-slug>` or provide '--project' flag")
+		userError.LogError(err)
+		os.Exit(1)
+	}
+
+	if templateSlug == "" {
+		err := userError.NewUserError(errors.New("Missing required argument 'template'"), "Missing required argument 'template'")
+		userError.LogError(err)
+		os.Exit(1)
+	}
+
+	rest := commands.NewRest()
+	response, err := rest.DevNet.SpawnRPC(accountID, projectSlug, templateSlug, accessKey, token)
+	if err != nil {
+		logrus.Error("Failed to spawn RPC", err)
+		return
+	}
+	logrus.Info(response)
+}

--- a/commands/devnet/spawn_rpc.go
+++ b/commands/devnet/spawn_rpc.go
@@ -18,40 +18,40 @@ var accessKey string
 var token string
 
 func init() {
-	spawnRpcCommand.PersistentFlags().StringVar(
+	cmdSpawnRpc.PersistentFlags().StringVar(
 		&accountID,
 		"account",
 		"",
 		"The Tenderly account username or organization slug. If not provided, the system will try to read 'account_id' from the 'tenderly.yaml' configuration file.",
 	)
-	spawnRpcCommand.PersistentFlags().StringVar(
+	cmdSpawnRpc.PersistentFlags().StringVar(
 		&projectSlug,
 		"project",
 		"",
 		"The DevNet project slug. If not provided, the system will try to read 'project_slug' from the 'tenderly.yaml' configuration file.",
 	)
-	spawnRpcCommand.PersistentFlags().StringVar(
+	cmdSpawnRpc.PersistentFlags().StringVar(
 		&templateSlug,
 		"template",
 		"",
 		"The DevNet template slug which is going to be applied when spawning the DevNet RPC.",
 	)
-	spawnRpcCommand.PersistentFlags().StringVar(
+	cmdSpawnRpc.PersistentFlags().StringVar(
 		&accessKey,
 		"access_key",
 		"",
 		"The Tenderly access key. If not provided, the system will try to read 'access_key' from the 'tenderly.yaml' configuration file.",
 	)
-	spawnRpcCommand.PersistentFlags().StringVar(
+	cmdSpawnRpc.PersistentFlags().StringVar(
 		&token,
 		"token",
 		"",
 		"The Tenderly JWT. If not provided, the system will try to read 'token' from the 'tenderly.yaml' configuration file.",
 	)
-	DevNetCmd.AddCommand(spawnRpcCommand)
+	CmdDevNet.AddCommand(cmdSpawnRpc)
 }
 
-var spawnRpcCommand = &cobra.Command{
+var cmdSpawnRpc = &cobra.Command{
 	Use:   "spawn-rpc",
 	Short: "Spawn DevNet RPC",
 	Long:  `Spawn DevNet RPC that represents the JSON-RPC endpoint for your DevNet`,
@@ -65,7 +65,10 @@ func spawnRPCHandler(cmd *cobra.Command, args []string) {
 	}
 
 	if accountID == "" {
-		err := userError.NewUserError(errors.New("account not found"), "No account found. Please login with `tenderly login` or provide '--account' flag")
+		err := userError.NewUserError(
+			errors.New("account not found"),
+			"An account is required. Please log in using tenderly login or include the '--account' flag.",
+		)
 		userError.LogError(err)
 		os.Exit(1)
 	}
@@ -79,7 +82,10 @@ func spawnRPCHandler(cmd *cobra.Command, args []string) {
 	}
 
 	if accessKey == "" && token == "" {
-		err := userError.NewUserError(errors.New("access key or token not found"), "No access key or token found. Please login with `tenderly login` or provide '--access_key' or '--token' flag")
+		err := userError.NewUserError(
+			errors.New("access key or token not found"),
+			"An access key or token is required. Please log in using tenderly login or include the '--access_key' or '--token' flag.",
+		)
 		userError.LogError(err)
 		os.Exit(1)
 	}
@@ -89,13 +95,19 @@ func spawnRPCHandler(cmd *cobra.Command, args []string) {
 	}
 
 	if projectSlug == "" {
-		err := userError.NewUserError(errors.New("project not found"), "No project found. Please set a project with `tenderly use project <project-slug>` or provide '--project' flag")
+		err := userError.NewUserError(
+			errors.New("project not found"),
+			"No project was found. To set a project, use tenderly use project <project-slug> or include the '--project' flag.",
+		)
 		userError.LogError(err)
 		os.Exit(1)
 	}
 
 	if templateSlug == "" {
-		err := userError.NewUserError(errors.New("Missing required argument 'template'"), "Missing required argument 'template'. Please provide '--template' flag with the DevNet template slug")
+		err := userError.NewUserError(
+			errors.New("Missing required argument 'template'"),
+			"The 'template' argument is required. Please include the '--template' flag and provide the DevNet template slug.",
+		)
 		userError.LogError(err)
 		os.Exit(1)
 	}

--- a/commands/devnet/spawn_rpc.go
+++ b/commands/devnet/spawn_rpc.go
@@ -47,7 +47,7 @@ func init() {
 		"",
 		"The Tenderly token. If not provided, the system will try to read 'token' from the 'tenderly.yaml' configuration file.",
 	)
-	commands.RootCmd.AddCommand(spawnRpcCommand)
+	DevNetCmd.AddCommand(spawnRpcCommand)
 }
 
 var spawnRpcCommand = &cobra.Command{

--- a/commands/devnet/spawn_rpc.go
+++ b/commands/devnet/spawn_rpc.go
@@ -1,13 +1,14 @@
 package devnet
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/tenderly/tenderly-cli/commands"
 	"github.com/tenderly/tenderly-cli/config"
 	"github.com/tenderly/tenderly-cli/userError"
-	"os"
 )
 
 var accountID string
@@ -21,7 +22,7 @@ func init() {
 		&accountID,
 		"account",
 		"",
-		"The Tenderly account. If not provided, the system will try to read 'account_id' from the 'tenderly.yaml' configuration file.",
+		"The Tenderly account username or organization slug. If not provided, the system will try to read 'account_id' from the 'tenderly.yaml' configuration file.",
 	)
 	spawnRpcCommand.PersistentFlags().StringVar(
 		&projectSlug,
@@ -33,7 +34,7 @@ func init() {
 		&templateSlug,
 		"template",
 		"",
-		"The DevNet template which is going to be applied when spawning the DevNet RPC.",
+		"The DevNet template slug which is going to be applied when spawning the DevNet RPC.",
 	)
 	spawnRpcCommand.PersistentFlags().StringVar(
 		&accessKey,
@@ -45,7 +46,7 @@ func init() {
 		&token,
 		"token",
 		"",
-		"The Tenderly token. If not provided, the system will try to read 'token' from the 'tenderly.yaml' configuration file.",
+		"The Tenderly JWT. If not provided, the system will try to read 'token' from the 'tenderly.yaml' configuration file.",
 	)
 	DevNetCmd.AddCommand(spawnRpcCommand)
 }
@@ -53,7 +54,7 @@ func init() {
 var spawnRpcCommand = &cobra.Command{
 	Use:   "spawn-rpc",
 	Short: "Spawn DevNet RPC",
-	Long:  `Spawn DevNet RPC that represents the network endpoint for your DevNet`,
+	Long:  `Spawn DevNet RPC that represents the JSON-RPC endpoint for your DevNet`,
 	Run:   spawnRPCHandler,
 }
 
@@ -94,7 +95,7 @@ func spawnRPCHandler(cmd *cobra.Command, args []string) {
 	}
 
 	if templateSlug == "" {
-		err := userError.NewUserError(errors.New("Missing required argument 'template'"), "Missing required argument 'template'")
+		err := userError.NewUserError(errors.New("Missing required argument 'template'"), "Missing required argument 'template'. Please provide '--template' flag with the DevNet template slug")
 		userError.LogError(err)
 		os.Exit(1)
 	}

--- a/commands/util.go
+++ b/commands/util.go
@@ -34,6 +34,7 @@ func NewRest() *rest.Rest {
 		call.NewExportCalls(),
 		call.NewNetworkCalls(),
 		call.NewActionCalls(),
+		call.NewDevNetCalls(),
 	)
 }
 

--- a/hardhat/hardhat.go
+++ b/hardhat/hardhat.go
@@ -22,6 +22,7 @@ func NewDeploymentProvider() *DeploymentProvider {
 		call.NewExportCalls(),
 		call.NewNetworkCalls(),
 		call.NewActionCalls(),
+		call.NewDevNetCalls(),
 	)
 
 	networks, err := rest.Networks.GetPublicNetworks()

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	// THIS IS HOW WE SUBSCRIBE NESTED COMMANDS
 	_ "github.com/tenderly/tenderly-cli/commands/actions"
 	_ "github.com/tenderly/tenderly-cli/commands/contract"
+	_ "github.com/tenderly/tenderly-cli/commands/devnet"
 	_ "github.com/tenderly/tenderly-cli/commands/export"
 )
 

--- a/rest/call/devnet.go
+++ b/rest/call/devnet.go
@@ -1,0 +1,57 @@
+package call
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/tenderly/tenderly-cli/config"
+	"github.com/tenderly/tenderly-cli/rest"
+	"github.com/tenderly/tenderly-cli/rest/client"
+	"github.com/tenderly/tenderly-cli/rest/payloads"
+)
+
+var _ rest.DevNetRoutes = (*DevNetCalls)(nil)
+
+type DevNetCalls struct{}
+
+func NewDevNetCalls() *DevNetCalls {
+	return &DevNetCalls{}
+}
+
+type SpawnRPCRequest struct {
+	Template string `json:"templateSlugOrId"`
+}
+
+func (rest *DevNetCalls) SpawnRPC(
+	accountID string,
+	projectID string,
+	templateSlug string,
+	accessKey string,
+	token string,
+) (string, error) {
+	req := &SpawnRPCRequest{
+		Template: templateSlug,
+	}
+	reqJson, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+	config.SetProjectConfig(config.AccessKey, accessKey)
+	config.SetProjectConfig(config.Token, token)
+	path := fmt.Sprintf("api/v1/account/%s/project/%s/devnet/container/spawn-rpc", accountID, projectID)
+	resp := client.Request(
+		"POST",
+		path,
+		reqJson,
+	)
+	var response *SpawnRPCResponse
+	err = json.NewDecoder(resp).Decode(&response)
+	if err != nil {
+		return "", err
+	}
+	return response.URL, err
+}
+
+type SpawnRPCResponse struct {
+	URL   string             `json:"url"`
+	Error *payloads.ApiError `json:"error"`
+}

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -43,6 +43,10 @@ type ActionRoutes interface {
 	Publish(request generatedActions.PublishRequest, projectSlug string) (*generatedActions.PublishResponse, error)
 }
 
+type DevNetRoutes interface {
+	SpawnRPC(accountID string, projectID string, templateSlug string, accessKey string, token string) (string, error)
+}
+
 type Rest struct {
 	Auth     AuthRoutes
 	User     UserRoutes
@@ -51,6 +55,7 @@ type Rest struct {
 	Export   ExportRoutes
 	Networks NetworkRoutes
 	Actions  ActionRoutes
+	DevNet   DevNetRoutes
 }
 
 func NewRest(
@@ -61,6 +66,7 @@ func NewRest(
 	export ExportRoutes,
 	networks NetworkRoutes,
 	actions ActionRoutes,
+	devnet DevNetRoutes,
 ) *Rest {
 	return &Rest{
 		Auth:     auth,
@@ -70,5 +76,6 @@ func NewRest(
 		Export:   export,
 		Networks: networks,
 		Actions:  actions,
+		DevNet:   devnet,
 	}
 }


### PR DESCRIPTION
### Context
This change adds support for `tenderly devnet spawn-rpc` cmd that can spawn a new devnet RPC URL based on the template