### PR TITLE
Make logrus log to Stdout

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -79,6 +79,8 @@ func initConfig() {
 func initLog() {
 	Colorizer = aurora.NewAurora(false)
 	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetOutput(os.Stdout)
+
 	if debugMode {
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.SetReportCaller(true)


### PR DESCRIPTION
Have cli output captured to os.Stdout to enable better scripting usage. By default it was os.Stderr.