### PR TITLE
Make `spawn-rpc` "return" url instead of logging/printing it

### DIFF
--- a/commands/devnet/spawn_rpc.go
+++ b/commands/devnet/spawn_rpc.go
@@ -1,8 +1,8 @@
 package devnet
 
 import (
-	"os"
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -17,6 +17,7 @@ var projectSlug string
 var templateSlug string
 var accessKey string
 var token string
+var returnUrl bool
 
 func init() {
 	cmdSpawnRpc.PersistentFlags().StringVar(
@@ -48,6 +49,12 @@ func init() {
 		"token",
 		"",
 		"The Tenderly JWT. If not provided, the system will try to read 'token' from the 'tenderly.yaml' configuration file.",
+	)
+	cmdSpawnRpc.PersistentFlags().BoolVar(
+		&returnUrl,
+		"return-url",
+		false,
+		"Optional flag to return the URL instead of printing it. Default: false.",
 	)
 	CmdDevNet.AddCommand(cmdSpawnRpc)
 }
@@ -119,6 +126,10 @@ func spawnRPCHandler(cmd *cobra.Command, args []string) {
 		logrus.Error("Failed to spawn RPC", err)
 		return
 	}
-	
-	fmt.Printf("%s\n", response)
+
+	if returnUrl {
+		fmt.Printf("%s\n", response)
+	} else {
+		logrus.Info(response)
+	}
 }

--- a/commands/devnet/spawn_rpc.go
+++ b/commands/devnet/spawn_rpc.go
@@ -2,6 +2,7 @@ package devnet
 
 import (
 	"os"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -118,5 +119,6 @@ func spawnRPCHandler(cmd *cobra.Command, args []string) {
 		logrus.Error("Failed to spawn RPC", err)
 		return
 	}
-	logrus.Info(response)
+	
+	fmt.Printf("%s\n", response)
 }


### PR DESCRIPTION
Current implementation just prints the URL instead of returning it, so the current command can't be used in bash scripts.