### PR TITLE
Fix typos in user-facing messages in logout.go and verify.go

### DIFF
--- a/commands/logout.go
+++ b/commands/logout.go
@@ -17,7 +17,7 @@ var logoutCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if !config.IsLoggedIn() {
 			logrus.Info(Colorizer.Sprintf("It seems that you are not logged in, in order to logout you need to " +
-				"be loged in first."))
+				"be logged in first."))
 			return
 		}
 

--- a/commands/verify.go
+++ b/commands/verify.go
@@ -88,7 +88,7 @@ func verifyContracts(rest *rest.Rest) error {
 	if numberOfContractsWithANetwork == 0 {
 		if DeploymentProvider.GetProviderName() == providers.OpenZeppelinDeploymentProvider {
 			return userError.NewUserError(
-				fmt.Errorf("no contracts with a netowork found in build dir: %s", providerConfig.AbsoluteBuildDirectoryPath()),
+				fmt.Errorf("no contracts with a network found in build dir: %s", providerConfig.AbsoluteBuildDirectoryPath()),
 				Colorizer.Sprintf("No migrated contracts detected in build directory: %s. This can happen when no contracts have been migrated yet.\n"+
 					"There is currently an issue with exporting networks for regular contracts.\n The OpenZeppelin team has come up with a workaround,"+
 					"so make sure you run %s before running %s\n"+


### PR DESCRIPTION
# Pull Request Description

## Changes Summary

### Update `logout.go`
- Fixed a typo in the logout message where "be loged in first" was corrected to "be logged in first".

### Update `verify.go`
- Resolved a typo in the error message where "no contracts with a netowork found" was corrected to "no contracts with a network found".

## Purpose
These changes address minor typographical errors in user-facing messages to enhance clarity and professionalism.
