### PR TITLE
refactor: use strings.EqualFold

### DIFF
--- a/commands/actions/common.go
+++ b/commands/actions/common.go
@@ -81,7 +81,7 @@ func chooseProject(rest *rest.Rest, accountID string, createNewOption bool, only
 
 				include := false
 				for _, slug := range onlySlugs {
-					if strings.ToLower(projectSlug) == strings.ToLower(slug) {
+					if strings.EqualFold(projectSlug, slug) {
 						include = true
 						break
 					}


### PR DESCRIPTION
strings.EqualFold has no memory overhead and has better performance than strings.ToLower.

This is a performance test:

```go
package bench

import (
	"strings"
	"testing"
)

func BenchmarkToLower(b *testing.B) {

	str1 := "Windows"
	str2 := "windows"

	for i := 0; i < b.N; i++ {
		if strings.ToLower(str1) == strings.ToLower(str2) {
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {

	str1 := "Windows"
	str2 := "windows"

	for i := 0; i < b.N; i++ {
		if strings.EqualFold(str1, str2) {
		}
	}
}
```

The result:
```
goos: darwin
goarch: arm64
BenchmarkToLower-8      31404808                36.99 ns/op            8 B/op          1 allocs/op
BenchmarkEqualFold-8    194780793                5.989 ns/op           0 B/op          0 allocs/op
PASS
```
