### PR TITLE
export duplicate removed

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -12,7 +12,7 @@ func init() {
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
-	Short: "The export feature has been deprecated in favor of the DevNets",
+	Short: "Deprecated: use DevNets instead",
 	Run: func(cmd *cobra.Command, args []string) {
 		logrus.Info(Colorizer.Sprintf(
 			"The export feature has been deprecated in favor of the %s.\n\n"+
@@ -28,7 +28,8 @@ var exportCmd = &cobra.Command{
 
 var exportInitCmd = &cobra.Command{
 	Use:   "export init",
-	Short: "The export feature has been deprecated in favor of the DevNets",
+	Short: "Deprecated: use DevNets instead",
+	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		logrus.Info(Colorizer.Sprintf(
 			"The export feature has been deprecated in favor of the %s.\n\n"+


### PR DESCRIPTION
The cli command currently displays `export` twice.

If this is intentional to allude to the "Deprecated" state of the `export` command - sorry, just close the PR. Otherwise, might make sense to merge so that it does not confuse the user (as it did with me). Thanks

======================

Tenderly CLI is a suite of development tools for smart contracts which allows your to monitor and debug them on any network.

To report a bug or give feedback send us an email at support@tenderly.co

Usage:
  tenderly [command]

Available Commands:
  actions         Create, build and deploy Web3 Actions.
  completion      Generate the autocompletion script for the specified shell
  contracts       Verify, push and remove contracts from project.
  devnet          Tenderly DevNets.
  export          The export feature has been deprecated in favor of the DevNets
  export          The export feature has been deprecated in favor of the DevNets
  help            Help about any command
  init            Initialize Tenderly CLI
  login           User authentication
  logout          Use this command to logout of the currently logged in Tenderly account
  node-extensions Create, build and deploy Node Extensions.
  update-check    Checks whether there is an update for the CLI
  version         Shows the version of the CLI
  whoami          Who am I?

Flags:
      --debug                   Turn on debug level logging.
      --global-config string    Global configuration file name (without the extension) (default "config")
  -h, --help                    help for tenderly
      --output string           Which output mode to use: text or json. If not provided, text output will be used. (default "text")
      --project-config string   Project configuration file name (without the extension) (default "tenderly")
      --project-dir string      The directory in which your Truffle project resides. If not provided assumes the current working directory. (default ".")
      --reset-provider          Clear set deployment provider. If not provided, will use provider from tenderly.yaml

Use "tenderly [command] --help" for more information about a command.

THat's how the fixed version looks now:
<img width="774" height="146" alt="image" src="https://github.com/user-attachments/assets/1f734db7-cdc5-4e90-8627-9ef2c387e5d2" />

