### PR TITLE
feat(actions): add ethBalance and stateChanged trigger support

### DIFF
--- a/commands/actions/capabilities.go
+++ b/commands/actions/capabilities.go
@@ -19,17 +19,18 @@ func init() {
 }
 
 type capabilitiesOutput struct {
-	Version                 string      `json:"version"`
+	Version                 string        `json:"version"`
 	Commands                []commandInfo `json:"commands"`
-	TriggerTypes            []string    `json:"trigger_types"`
-	Runtimes                []string    `json:"runtimes"`
-	ExecutionTypes          []string    `json:"execution_types"`
-	Intervals               []string    `json:"intervals"`
-	Invocations             []string    `json:"invocations"`
-	StatusValues            []string    `json:"status_values"`
-	TransactionStatusValues []string    `json:"transaction_status_values"`
-	SchemaCommand           string      `json:"schema_command"`
-	Schema                  interface{} `json:"schema,omitempty"`
+	TriggerTypes            []string      `json:"trigger_types"`
+	TransactionFilterTypes  []string      `json:"transaction_filter_types"`
+	Runtimes                []string      `json:"runtimes"`
+	ExecutionTypes          []string      `json:"execution_types"`
+	Intervals               []string      `json:"intervals"`
+	Invocations             []string      `json:"invocations"`
+	StatusValues            []string      `json:"status_values"`
+	TransactionStatusValues []string      `json:"transaction_status_values"`
+	SchemaCommand           string        `json:"schema_command"`
+	Schema                  interface{}   `json:"schema,omitempty"`
 }
 
 type commandInfo struct {
@@ -53,6 +54,7 @@ var capabilitiesCmd = &cobra.Command{
 			Version:                 commands.CurrentCLIVersion,
 			Commands:                cmds,
 			TriggerTypes:            actionsModel.TriggerTypes,
+			TransactionFilterTypes:  actionsModel.TransactionFilterTypes,
 			Runtimes:                actionsModel.SupportedRuntimes,
 			ExecutionTypes:          []string{actionsModel.SequentialExecutionType, actionsModel.ParallelExecutionType},
 			Intervals:               actionsModel.Intervals,

--- a/commands/actions/capabilities_test.go
+++ b/commands/actions/capabilities_test.go
@@ -14,6 +14,7 @@ func TestCapabilitiesOutput_JSONShape(t *testing.T) {
 		Version:                 "v0.0.0-test",
 		Commands:                []commandInfo{{Name: "test", Description: "test cmd"}},
 		TriggerTypes:            actionsModel.TriggerTypes,
+		TransactionFilterTypes:  actionsModel.TransactionFilterTypes,
 		Runtimes:                actionsModel.SupportedRuntimes,
 		ExecutionTypes:          []string{actionsModel.SequentialExecutionType, actionsModel.ParallelExecutionType},
 		Intervals:               actionsModel.Intervals,
@@ -35,6 +36,7 @@ func TestCapabilitiesOutput_JSONShape(t *testing.T) {
 	assert.Equal(t, "tenderly actions schema", parsed["schema_command"])
 	assert.NotNil(t, parsed["commands"])
 	assert.NotNil(t, parsed["trigger_types"])
+	assert.NotNil(t, parsed["transaction_filter_types"])
 	assert.NotNil(t, parsed["runtimes"])
 	assert.NotNil(t, parsed["execution_types"])
 	assert.NotNil(t, parsed["intervals"])
@@ -70,13 +72,15 @@ func TestCapabilitiesOutput_WithSchema(t *testing.T) {
 
 func TestCapabilitiesOutput_EnumsInSyncWithConstants(t *testing.T) {
 	out := capabilitiesOutput{
-		TriggerTypes:            actionsModel.TriggerTypes,
-		Runtimes:                actionsModel.SupportedRuntimes,
-		Intervals:               actionsModel.Intervals,
-		Invocations:             actionsModel.Invocations,
+		TriggerTypes:           actionsModel.TriggerTypes,
+		TransactionFilterTypes: actionsModel.TransactionFilterTypes,
+		Runtimes:               actionsModel.SupportedRuntimes,
+		Intervals:              actionsModel.Intervals,
+		Invocations:            actionsModel.Invocations,
 	}
 
 	assert.Equal(t, actionsModel.TriggerTypes, out.TriggerTypes)
+	assert.Equal(t, actionsModel.TransactionFilterTypes, out.TransactionFilterTypes)
 	assert.Equal(t, actionsModel.SupportedRuntimes, out.Runtimes)
 	assert.Equal(t, actionsModel.Intervals, out.Intervals)
 	assert.Equal(t, actionsModel.Invocations, out.Invocations)

--- a/model/actions/const.go
+++ b/model/actions/const.go
@@ -80,5 +80,10 @@ var (
 	MsgStartsWithInvalid                   = "'startsWith' element must be hex encoded and start with 0x"
 	MsgHexValueEmpty                       = "expected non-empty hex value"
 	MsgHexValueInvalid                     = "hex value must start with 0x, got %s"
-	MsgMinFilterConstraint                 = "constraint for minimum transaction filters must be fulfilled"
+	MsgMinFilterConstraint                = "constraint for minimum transaction filters must be fulfilled"
+	MsgAddressRequired                    = "'address' is required"
+	MsgBigIntNoConditionSet               = "must have at least one condition set (gte, lte, eq, gt, lt)"
+	MsgBigIntValueInvalid                 = "value '%s' must be a valid non-negative integer (decimal or 0x-prefixed hex)"
+	MsgStateChangedParamConditionRequired = "at least one of 'change', 'valueCmp', 'percentageCmp', 'storageSlotKey' is required"
+	MsgParamNameRequired                  = "'name' is required for parameter condition"
 )

--- a/model/actions/const.go
+++ b/model/actions/const.go
@@ -16,7 +16,8 @@ var (
 	BlockType          = "block"
 	TransactionType    = "transaction"
 	AlertType          = "alert"
-	Invocations        = []string{"any", "direct", "internal"}
+	TransactionFilterTypes = []string{"from", "to", "function", "eventEmitted", "logEmitted", "ethBalance", "stateChanged"}
+	Invocations           = []string{"any", "direct", "internal"}
 	InvocationAny      = "any"
 	InvocationDirect   = "direct"
 	InvocationInternal = "internal"

--- a/model/actions/const.go
+++ b/model/actions/const.go
@@ -84,7 +84,7 @@ var (
 	MsgMinFilterConstraint                = "constraint for minimum transaction filters must be fulfilled"
 	MsgAddressRequired                    = "'address' is required"
 	MsgBigIntNoConditionSet               = "must have at least one condition set (gte, lte, eq, gt, lt)"
-	MsgBigIntValueInvalid                 = "value '%s' must be a valid non-negative integer (decimal or 0x-prefixed hex)"
+	MsgBigIntValueInvalid                 = "value '%s' must be a valid integer (decimal or 0x-prefixed hex)"
 	MsgStateChangedParamConditionRequired = "at least one of 'change', 'valueCmp', 'percentageCmp', 'storageSlotKey' is required"
 	MsgParamNameRequired                  = "'name' is required for parameter condition"
 )

--- a/model/actions/schema.go
+++ b/model/actions/schema.go
@@ -407,7 +407,7 @@ func defLogEmittedField() map[string]interface{} {
 }
 
 func defBigIntValue() map[string]interface{} {
-	bigIntString := obj("type", "string", "pattern", "^(0x[0-9a-fA-F]+|[0-9]+)$")
+	bigIntString := obj("type", "string", "pattern", "^(-?0x[0-9a-fA-F]+|-?[0-9]+)$")
 	return obj(
 		"type", "object",
 		"properties", obj(

--- a/model/actions/schema.go
+++ b/model/actions/schema.go
@@ -158,17 +158,23 @@ func buildDefs() map[string]interface{} {
 		"Hex64":                 defHex64(),
 
 		// Composite types
-		"ContractValue":           defContractValue(),
+		"ContractValue":            defContractValue(),
 		"AddressOnlyContractValue": defAddressOnlyContractValue(),
-		"StrValue":                defStrValue(),
-		"ParameterCondValue":      defParameterCondValue(),
-		"FunctionValue":           defFunctionValue(),
-		"FunctionField":           defFunctionField(),
-		"EventEmittedValue":       defEventEmittedValue(),
-		"EventEmittedField":       defEventEmittedField(),
-		"LogEmittedValue":         defLogEmittedValue(),
-		"LogEmittedField":         defLogEmittedField(),
-		"TransactionFilter":       defTransactionFilter(),
+		"StrValue":                 defStrValue(),
+		"ParameterCondValue":       defParameterCondValue(),
+		"FunctionValue":            defFunctionValue(),
+		"FunctionField":            defFunctionField(),
+		"EventEmittedValue":        defEventEmittedValue(),
+		"EventEmittedField":        defEventEmittedField(),
+		"LogEmittedValue":          defLogEmittedValue(),
+		"LogEmittedField":          defLogEmittedField(),
+		"BigIntValue":              defBigIntValue(),
+		"EthBalanceValue":          defEthBalanceValue(),
+		"EthBalanceField":          defEthBalanceField(),
+		"StateChangedParamCondValue": defStateChangedParamCondValue(),
+		"StateChangedValue":        defStateChangedValue(),
+		"StateChangedField":        defStateChangedField(),
+		"TransactionFilter":        defTransactionFilter(),
 
 		// Trigger types
 		"PeriodicTrigger":    defPeriodicTrigger(),
@@ -400,6 +406,74 @@ func defLogEmittedField() map[string]interface{} {
 	return singleOrArray(refDef("LogEmittedValue"))
 }
 
+func defBigIntValue() map[string]interface{} {
+	bigIntString := obj("type", "string", "pattern", "^(0x[0-9a-fA-F]+|[0-9]+)$")
+	return obj(
+		"type", "object",
+		"properties", obj(
+			"gte", bigIntString,
+			"lte", bigIntString,
+			"eq", bigIntString,
+			"gt", bigIntString,
+			"lt", bigIntString,
+			"not", obj("type", "boolean"),
+		),
+		"additionalProperties", false,
+	)
+}
+
+func defEthBalanceValue() map[string]interface{} {
+	return obj(
+		"type", "object",
+		"properties", obj(
+			"address", refDef("AddressValue"),
+			"balanceCmp", refDef("BigIntValue"),
+			"not", obj("type", "boolean"),
+		),
+		"required", arr("address", "balanceCmp"),
+		"additionalProperties", false,
+	)
+}
+
+func defEthBalanceField() map[string]interface{} {
+	return singleOrArray(refDef("EthBalanceValue"))
+}
+
+func defStateChangedParamCondValue() map[string]interface{} {
+	return obj(
+		"type", "object",
+		"properties", obj(
+			"name", obj("type", "string"),
+			"change", obj("type", "boolean"),
+			"valueCmp", refDef("BigIntValue"),
+			"percentageCmp", refDef("BigIntValue"),
+			"storageSlotKey", obj("type", "string"),
+		),
+		"required", arr("name"),
+		"additionalProperties", false,
+	)
+}
+
+func defStateChangedValue() map[string]interface{} {
+	return obj(
+		"type", "object",
+		"properties", obj(
+			"address", refDef("AddressValue"),
+			"matchAny", obj("type", "boolean"),
+			"params", obj(
+				"type", "array",
+				"items", refDef("StateChangedParamCondValue"),
+			),
+			"not", obj("type", "boolean"),
+		),
+		"additionalProperties", false,
+	)
+}
+
+func defStateChangedField() map[string]interface{} {
+	return singleOrArray(refDef("StateChangedValue"))
+}
+
 func defTransactionFilter() map[string]interface{} {
 	return obj(
 		"type", "object",
@@ -416,6 +490,8 @@ func defTransactionFilter() map[string]interface{} {
 			"function", refDef("FunctionField"),
 			"eventEmitted", refDef("EventEmittedField"),
 			"logEmitted", refDef("LogEmittedField"),
+			"ethBalance", refDef("EthBalanceField"),
+			"stateChanged", refDef("StateChangedField"),
 		),
 		"required", arr("network"),
 		"anyOf", arr(
@@ -424,6 +500,8 @@ func defTransactionFilter() map[string]interface{} {
 			obj("required", arr("function")),
 			obj("required", arr("eventEmitted")),
 			obj("required", arr("logEmitted")),
+			obj("required", arr("ethBalance")),
+			obj("required", arr("stateChanged")),
 		),
 		"additionalProperties", false,
 	)

--- a/model/actions/schema_test.go
+++ b/model/actions/schema_test.go
@@ -37,17 +37,17 @@ func TestGenerateJSONSchema_HasAllDefs(t *testing.T) {
 		"FunctionValue", "FunctionField",
 		"EventEmittedValue", "EventEmittedField",
 		"LogEmittedValue", "LogEmittedField",
+		"BigIntValue", "EthBalanceValue", "EthBalanceField",
+		"StateChangedParamCondValue", "StateChangedValue", "StateChangedField",
 		"TransactionFilter",
 		"PeriodicTrigger", "WebhookTrigger", "BlockTrigger",
 		"TransactionTrigger", "AlertTrigger",
 		"TriggerUnparsed", "ActionSpec", "ProjectActions",
 	}
 
-	// Unsupported features should NOT be in schema
+	// These legacy types should NOT be in schema
 	removedDefs := []string{
 		"AnyValue", "MapValue", "AccountValue",
-		"StateChangedValue", "StateChangedField",
-		"EthBalanceValue", "EthBalanceField",
 	}
 	for _, name := range removedDefs {
 		_, exists := defs[name]
@@ -189,15 +189,15 @@ func TestGenerateJSONSchema_TransactionFilterRequiresNetwork(t *testing.T) {
 	assert.Contains(t, required, "network")
 }
 
-func TestGenerateJSONSchema_TransactionFilterNoUnsupportedFields(t *testing.T) {
+func TestGenerateJSONSchema_TransactionFilterHasEthBalanceAndStateChanged(t *testing.T) {
 	schema := GenerateJSONSchema()
 	defs := schema["$defs"].(map[string]interface{})
 	tf := defs["TransactionFilter"].(map[string]interface{})
 	props := tf["properties"].(map[string]interface{})
 	_, hasEthBalance := props["ethBalance"]
 	_, hasStateChanged := props["stateChanged"]
-	assert.False(t, hasEthBalance, "ethBalance should not be in TransactionFilter (not yet supported)")
-	assert.False(t, hasStateChanged, "stateChanged should not be in TransactionFilter (not yet supported)")
+	assert.True(t, hasEthBalance, "ethBalance should be in TransactionFilter")
+	assert.True(t, hasStateChanged, "stateChanged should be in TransactionFilter")
 }
 
 func TestGenerateJSONSchema_LogEmittedContractNoInvocation(t *testing.T) {
@@ -249,9 +249,9 @@ func TestGenerateJSONSchema_TransactionFilterMinConstraint(t *testing.T) {
 	defs := schema["$defs"].(map[string]interface{})
 	tf := defs["TransactionFilter"].(map[string]interface{})
 	anyOf := tf["anyOf"].([]interface{})
-	require.Len(t, anyOf, 5, "anyOf should require at least one of from/to/function/eventEmitted/logEmitted")
+	require.Len(t, anyOf, 7, "anyOf should require at least one of from/to/function/eventEmitted/logEmitted/ethBalance/stateChanged")
 
-	expectedFields := []string{"from", "to", "function", "eventEmitted", "logEmitted"}
+	expectedFields := []string{"from", "to", "function", "eventEmitted", "logEmitted", "ethBalance", "stateChanged"}
 	for i, entry := range anyOf {
 		branch := entry.(map[string]interface{})
 		required := branch["required"].([]interface{})
@@ -297,6 +297,38 @@ func TestGenerateJSONSchema_SignaturePatternCaseInsensitive(t *testing.T) {
 	oneOf := sig["oneOf"].([]interface{})
 	strBranch := oneOf[0].(map[string]interface{})
 	assert.Equal(t, SigRegexCI, strBranch["pattern"], "schema should use case-insensitive sig regex")
+}
+
+func TestGenerateJSONSchema_BigIntValuePattern(t *testing.T) {
+	schema := GenerateJSONSchema()
+	defs := schema["$defs"].(map[string]interface{})
+	bigInt := defs["BigIntValue"].(map[string]interface{})
+	props := bigInt["properties"].(map[string]interface{})
+
+	expectedFields := []string{"gte", "lte", "eq", "gt", "lt", "not"}
+	for _, field := range expectedFields {
+		_, exists := props[field]
+		assert.True(t, exists, "BigIntValue should have field %q", field)
+	}
+	assert.Equal(t, false, bigInt["additionalProperties"], "BigIntValue should not allow additional properties")
+}
+
+func TestGenerateJSONSchema_EthBalanceValueRequiresAddressAndBalanceCmp(t *testing.T) {
+	schema := GenerateJSONSchema()
+	defs := schema["$defs"].(map[string]interface{})
+	ebv := defs["EthBalanceValue"].(map[string]interface{})
+	required := ebv["required"].([]interface{})
+	assert.Contains(t, required, "address")
+	assert.Contains(t, required, "balanceCmp")
+}
+
+func TestGenerateJSONSchema_StateChangedParamCondRequiresName(t *testing.T) {
+	schema := GenerateJSONSchema()
+	defs := schema["$defs"].(map[string]interface{})
+	param := defs["StateChangedParamCondValue"].(map[string]interface{})
+	required := param["required"].([]interface{})
+	assert.Contains(t, required, "name")
+	assert.Equal(t, false, param["additionalProperties"], "StateChangedParamCondValue should not allow additional properties")
 }
 
 // --- ValidateConfig integration tests ---

--- a/model/actions/trigger_eth_balance_test.go
+++ b/model/actions/trigger_eth_balance_test.go
@@ -1,0 +1,185 @@
+package actions_test
+
+import (
+	"testing"
+)
+
+func TestEthBalanceGte(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_eth_balance")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.EthBalance) != 1 {
+		t.Fatalf("expected 1 ethBalance filter, got %d", len(req.EthBalance))
+	}
+	eb := req.EthBalance[0]
+	if eb.Address != "0x13253c152f4d724d15d7b064de106a739551da5f" {
+		t.Errorf("expected address '0x13253c152f4d724d15d7b064de106a739551da5f', got %q", eb.Address)
+	}
+	if eb.BalanceCmp.Gte == nil {
+		t.Fatal("expected BalanceCmp.Gte to be set")
+	}
+	if *eb.BalanceCmp.Gte != "0xde0b6b3a7640000" {
+		t.Errorf("expected BalanceCmp.Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
+	}
+	if eb.Not {
+		t.Error("expected Not to be false")
+	}
+}
+
+func TestEthBalanceNot(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_eth_balance_not")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.EthBalance) != 1 {
+		t.Fatalf("expected 1 ethBalance filter, got %d", len(req.EthBalance))
+	}
+	eb := req.EthBalance[0]
+	if eb.BalanceCmp.Lte == nil {
+		t.Fatal("expected BalanceCmp.Lte to be set")
+	}
+	if !eb.Not {
+		t.Error("expected Not to be true")
+	}
+}
+
+func TestEthBalanceHexInput(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_eth_balance_hex")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.EthBalance) != 1 {
+		t.Fatalf("expected 1 ethBalance filter, got %d", len(req.EthBalance))
+	}
+	eb := req.EthBalance[0]
+	if eb.BalanceCmp.Gte == nil {
+		t.Fatal("expected BalanceCmp.Gte to be set")
+	}
+	if *eb.BalanceCmp.Gte != "0xde0b6b3a7640000" {
+		t.Errorf("expected BalanceCmp.Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
+	}
+}
+
+func TestEthBalanceMissingAddress(t *testing.T) {
+	_, response, ok := MustReadTrigger("trigger_eth_balance_invalid_missing_address")
+	if ok {
+		t.Fatal("expected validation to fail when address is missing")
+	}
+	found := false
+	for _, e := range response.Errors {
+		if e == "test.transaction.filters.0.ethBalance.address: 'address' is required" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected address required error, got: %v", response.Errors)
+	}
+}
+
+func TestEthBalanceNoCmp(t *testing.T) {
+	_, response, ok := MustReadTrigger("trigger_eth_balance_invalid_no_cmp")
+	if ok {
+		t.Fatal("expected validation to fail when balanceCmp has no conditions")
+	}
+	found := false
+	for _, e := range response.Errors {
+		if e == "test.transaction.filters.0.ethBalance.balanceCmp: must have at least one condition set (gte, lte, eq, gt, lt)" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected balanceCmp no-condition error, got: %v", response.Errors)
+	}
+}
+
+func TestEthBalanceEq(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_eth_balance_eq")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.EthBalance) != 1 {
+		t.Fatalf("expected 1 ethBalance filter, got %d", len(req.EthBalance))
+	}
+	eb := req.EthBalance[0]
+	if eb.BalanceCmp.Eq == nil {
+		t.Fatal("expected BalanceCmp.Eq to be set")
+	}
+	if *eb.BalanceCmp.Eq != "0xde0b6b3a7640000" {
+		t.Errorf("expected BalanceCmp.Eq '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Eq)
+	}
+	if eb.BalanceCmp.Gte != nil || eb.BalanceCmp.Lte != nil || eb.BalanceCmp.Gt != nil || eb.BalanceCmp.Lt != nil {
+		t.Error("expected only Eq to be set")
+	}
+}
+
+func TestEthBalanceRange(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_eth_balance_range")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.EthBalance) != 1 {
+		t.Fatalf("expected 1 ethBalance filter, got %d", len(req.EthBalance))
+	}
+	eb := req.EthBalance[0]
+	if eb.BalanceCmp.Gte == nil {
+		t.Fatal("expected BalanceCmp.Gte to be set")
+	}
+	if eb.BalanceCmp.Lte == nil {
+		t.Fatal("expected BalanceCmp.Lte to be set")
+	}
+	if *eb.BalanceCmp.Gte != "0xde0b6b3a7640000" {
+		t.Errorf("expected Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
+	}
+	if *eb.BalanceCmp.Lte != "0x1bc16d674ec80000" {
+		t.Errorf("expected Lte '0x1bc16d674ec80000', got %q", *eb.BalanceCmp.Lte)
+	}
+}
+
+func TestEthBalanceMulti(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_eth_balance_multi")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.EthBalance) != 2 {
+		t.Fatalf("expected 2 ethBalance filters, got %d", len(req.EthBalance))
+	}
+	if req.EthBalance[0].Address != "0x13253c152f4d724d15d7b064de106a739551da5f" {
+		t.Errorf("expected first address '0x13253c152f4d724d15d7b064de106a739551da5f', got %q", req.EthBalance[0].Address)
+	}
+	if req.EthBalance[0].BalanceCmp.Gte == nil {
+		t.Fatal("expected first filter Gte to be set")
+	}
+	if req.EthBalance[1].Address != "0xd8da6bf26964af9d7eed9e03e53415d37aa96045" {
+		t.Errorf("expected second address '0xd8da6bf26964af9d7eed9e03e53415d37aa96045', got %q", req.EthBalance[1].Address)
+	}
+	if req.EthBalance[1].BalanceCmp.Lte == nil {
+		t.Fatal("expected second filter Lte to be set")
+	}
+}
+
+func TestEthBalanceInvalidBadHex(t *testing.T) {
+	_, response, ok := MustReadTrigger("trigger_eth_balance_invalid_bad_hex")
+	if ok {
+		t.Fatal("expected validation to fail for malformed hex value")
+	}
+	found := false
+	for _, e := range response.Errors {
+		if e == "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '0xZZZ' must be a valid non-negative integer (decimal or 0x-prefixed hex)" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected invalid hex error, got: %v", response.Errors)
+	}
+}
+
+func TestEthBalanceInvalidNegative(t *testing.T) {
+	_, response, ok := MustReadTrigger("trigger_eth_balance_invalid_negative")
+	if ok {
+		t.Fatal("expected validation to fail for negative value")
+	}
+	found := false
+	for _, e := range response.Errors {
+		if e == "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '-1' must be a valid non-negative integer (decimal or 0x-prefixed hex)" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected negative value error, got: %v", response.Errors)
+	}
+}

--- a/model/actions/trigger_eth_balance_test.go
+++ b/model/actions/trigger_eth_balance_test.go
@@ -19,7 +19,7 @@ func TestEthBalanceGte(t *testing.T) {
 		t.Fatal("expected BalanceCmp.Gte to be set")
 	}
 	if *eb.BalanceCmp.Gte != "1000000000000000000" {
-		t.Errorf("expected BalanceCmp.Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
+		t.Errorf("expected BalanceCmp.Gte '1000000000000000000', got %q", *eb.BalanceCmp.Gte)
 	}
 	if eb.Not {
 		t.Error("expected Not to be false")
@@ -54,7 +54,7 @@ func TestEthBalanceHexInput(t *testing.T) {
 		t.Fatal("expected BalanceCmp.Gte to be set")
 	}
 	if *eb.BalanceCmp.Gte != "1000000000000000000" {
-		t.Errorf("expected BalanceCmp.Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
+		t.Errorf("expected BalanceCmp.Gte '1000000000000000000', got %q", *eb.BalanceCmp.Gte)
 	}
 }
 
@@ -63,15 +63,7 @@ func TestEthBalanceMissingAddress(t *testing.T) {
 	if ok {
 		t.Fatal("expected validation to fail when address is missing")
 	}
-	found := false
-	for _, e := range response.Errors {
-		if e == "test.transaction.filters.0.ethBalance.address: 'address' is required" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected address required error, got: %v", response.Errors)
-	}
+	requireValidationError(t, response, "test.transaction.filters.0.ethBalance.address: 'address' is required")
 }
 
 func TestEthBalanceNoCmp(t *testing.T) {
@@ -79,15 +71,7 @@ func TestEthBalanceNoCmp(t *testing.T) {
 	if ok {
 		t.Fatal("expected validation to fail when balanceCmp has no conditions")
 	}
-	found := false
-	for _, e := range response.Errors {
-		if e == "test.transaction.filters.0.ethBalance.balanceCmp: must have at least one condition set (gte, lte, eq, gt, lt)" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected balanceCmp no-condition error, got: %v", response.Errors)
-	}
+	requireValidationError(t, response, "test.transaction.filters.0.ethBalance.balanceCmp: must have at least one condition set (gte, lte, eq, gt, lt)")
 }
 
 func TestEthBalanceEq(t *testing.T) {
@@ -102,7 +86,7 @@ func TestEthBalanceEq(t *testing.T) {
 		t.Fatal("expected BalanceCmp.Eq to be set")
 	}
 	if *eb.BalanceCmp.Eq != "1000000000000000000" {
-		t.Errorf("expected BalanceCmp.Eq '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Eq)
+		t.Errorf("expected BalanceCmp.Eq '1000000000000000000', got %q", *eb.BalanceCmp.Eq)
 	}
 	if eb.BalanceCmp.Gte != nil || eb.BalanceCmp.Lte != nil || eb.BalanceCmp.Gt != nil || eb.BalanceCmp.Lt != nil {
 		t.Error("expected only Eq to be set")
@@ -124,10 +108,10 @@ func TestEthBalanceRange(t *testing.T) {
 		t.Fatal("expected BalanceCmp.Lte to be set")
 	}
 	if *eb.BalanceCmp.Gte != "1000000000000000000" {
-		t.Errorf("expected Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
+		t.Errorf("expected Gte '1000000000000000000', got %q", *eb.BalanceCmp.Gte)
 	}
 	if *eb.BalanceCmp.Lte != "2000000000000000000" {
-		t.Errorf("expected Lte '0x1bc16d674ec80000', got %q", *eb.BalanceCmp.Lte)
+		t.Errorf("expected Lte '2000000000000000000', got %q", *eb.BalanceCmp.Lte)
 	}
 }
 
@@ -157,15 +141,7 @@ func TestEthBalanceInvalidBadHex(t *testing.T) {
 	if ok {
 		t.Fatal("expected validation to fail for malformed hex value")
 	}
-	found := false
-	for _, e := range response.Errors {
-		if e == "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '0xZZZ' must be a valid non-negative integer (decimal or 0x-prefixed hex)" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected invalid hex error, got: %v", response.Errors)
-	}
+	requireValidationError(t, response, "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '0xZZZ' must be a valid non-negative integer (decimal or 0x-prefixed hex)")
 }
 
 func TestEthBalanceInvalidNegative(t *testing.T) {
@@ -173,13 +149,5 @@ func TestEthBalanceInvalidNegative(t *testing.T) {
 	if ok {
 		t.Fatal("expected validation to fail for negative value")
 	}
-	found := false
-	for _, e := range response.Errors {
-		if e == "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '-1' must be a valid non-negative integer (decimal or 0x-prefixed hex)" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected negative value error, got: %v", response.Errors)
-	}
+	requireValidationError(t, response, "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '-1' must be a valid non-negative integer (decimal or 0x-prefixed hex)")
 }

--- a/model/actions/trigger_eth_balance_test.go
+++ b/model/actions/trigger_eth_balance_test.go
@@ -141,13 +141,20 @@ func TestEthBalanceInvalidBadHex(t *testing.T) {
 	if ok {
 		t.Fatal("expected validation to fail for malformed hex value")
 	}
-	requireValidationError(t, response, "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '0xZZZ' must be a valid non-negative integer (decimal or 0x-prefixed hex)")
+	requireValidationError(t, response, "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '0xZZZ' must be a valid integer (decimal or 0x-prefixed hex)")
 }
 
-func TestEthBalanceInvalidNegative(t *testing.T) {
-	_, response, ok := MustReadTrigger("trigger_eth_balance_invalid_negative")
-	if ok {
-		t.Fatal("expected validation to fail for negative value")
+func TestEthBalanceNegativeValue(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_eth_balance_invalid_negative")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.EthBalance) != 1 {
+		t.Fatalf("expected 1 ethBalance filter, got %d", len(req.EthBalance))
 	}
-	requireValidationError(t, response, "test.transaction.filters.0.ethBalance.balanceCmp.gte: value '-1' must be a valid non-negative integer (decimal or 0x-prefixed hex)")
+	if req.EthBalance[0].BalanceCmp.Gte == nil {
+		t.Fatal("expected BalanceCmp.Gte to be set")
+	}
+	if *req.EthBalance[0].BalanceCmp.Gte != "-1" {
+		t.Errorf("expected BalanceCmp.Gte '-1', got %q", *req.EthBalance[0].BalanceCmp.Gte)
+	}
 }

--- a/model/actions/trigger_eth_balance_test.go
+++ b/model/actions/trigger_eth_balance_test.go
@@ -18,7 +18,7 @@ func TestEthBalanceGte(t *testing.T) {
 	if eb.BalanceCmp.Gte == nil {
 		t.Fatal("expected BalanceCmp.Gte to be set")
 	}
-	if *eb.BalanceCmp.Gte != "0xde0b6b3a7640000" {
+	if *eb.BalanceCmp.Gte != "1000000000000000000" {
 		t.Errorf("expected BalanceCmp.Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
 	}
 	if eb.Not {
@@ -53,7 +53,7 @@ func TestEthBalanceHexInput(t *testing.T) {
 	if eb.BalanceCmp.Gte == nil {
 		t.Fatal("expected BalanceCmp.Gte to be set")
 	}
-	if *eb.BalanceCmp.Gte != "0xde0b6b3a7640000" {
+	if *eb.BalanceCmp.Gte != "1000000000000000000" {
 		t.Errorf("expected BalanceCmp.Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
 	}
 }
@@ -101,7 +101,7 @@ func TestEthBalanceEq(t *testing.T) {
 	if eb.BalanceCmp.Eq == nil {
 		t.Fatal("expected BalanceCmp.Eq to be set")
 	}
-	if *eb.BalanceCmp.Eq != "0xde0b6b3a7640000" {
+	if *eb.BalanceCmp.Eq != "1000000000000000000" {
 		t.Errorf("expected BalanceCmp.Eq '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Eq)
 	}
 	if eb.BalanceCmp.Gte != nil || eb.BalanceCmp.Lte != nil || eb.BalanceCmp.Gt != nil || eb.BalanceCmp.Lt != nil {
@@ -123,10 +123,10 @@ func TestEthBalanceRange(t *testing.T) {
 	if eb.BalanceCmp.Lte == nil {
 		t.Fatal("expected BalanceCmp.Lte to be set")
 	}
-	if *eb.BalanceCmp.Gte != "0xde0b6b3a7640000" {
+	if *eb.BalanceCmp.Gte != "1000000000000000000" {
 		t.Errorf("expected Gte '0xde0b6b3a7640000', got %q", *eb.BalanceCmp.Gte)
 	}
-	if *eb.BalanceCmp.Lte != "0x1bc16d674ec80000" {
+	if *eb.BalanceCmp.Lte != "2000000000000000000" {
 		t.Errorf("expected Lte '0x1bc16d674ec80000', got %q", *eb.BalanceCmp.Lte)
 	}
 }

--- a/model/actions/trigger_state_changed_test.go
+++ b/model/actions/trigger_state_changed_test.go
@@ -123,15 +123,7 @@ func TestStateChangedMissingAddress(t *testing.T) {
 	if ok {
 		t.Fatal("expected validation to fail when address is missing and matchAny is not set")
 	}
-	found := false
-	for _, e := range response.Errors {
-		if e == "test.transaction.filters.0.stateChanged.address: 'address' is required" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected address required error, got: %v", response.Errors)
-	}
+	requireValidationError(t, response, "test.transaction.filters.0.stateChanged.address: 'address' is required")
 }
 
 func TestStateChangedParamMissingName(t *testing.T) {
@@ -139,15 +131,7 @@ func TestStateChangedParamMissingName(t *testing.T) {
 	if ok {
 		t.Fatal("expected validation to fail when param name is missing")
 	}
-	found := false
-	for _, e := range response.Errors {
-		if e == "test.transaction.filters.0.stateChanged.params.0: 'name' is required for parameter condition" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected param name required error, got: %v", response.Errors)
-	}
+	requireValidationError(t, response, "test.transaction.filters.0.stateChanged.params.0: 'name' is required for parameter condition")
 }
 
 func TestStateChangedParamNoCondition(t *testing.T) {
@@ -155,15 +139,7 @@ func TestStateChangedParamNoCondition(t *testing.T) {
 	if ok {
 		t.Fatal("expected validation to fail when param has no condition")
 	}
-	found := false
-	for _, e := range response.Errors {
-		if e == "test.transaction.filters.0.stateChanged.params.0: at least one of 'change', 'valueCmp', 'percentageCmp', 'storageSlotKey' is required" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected param condition required error, got: %v", response.Errors)
-	}
+	requireValidationError(t, response, "test.transaction.filters.0.stateChanged.params.0: at least one of 'change', 'valueCmp', 'percentageCmp', 'storageSlotKey' is required")
 }
 
 func TestStateChangedMultiParams(t *testing.T) {

--- a/model/actions/trigger_state_changed_test.go
+++ b/model/actions/trigger_state_changed_test.go
@@ -1,0 +1,198 @@
+package actions_test
+
+import (
+	"testing"
+)
+
+func TestStateChangedChange(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_state_changed_change")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.StateChanged) != 1 {
+		t.Fatalf("expected 1 stateChanged filter, got %d", len(req.StateChanged))
+	}
+	sc := req.StateChanged[0]
+	if sc.Address != "0x13253c152f4d724d15d7b064de106a739551da5f" {
+		t.Errorf("expected address '0x13253c152f4d724d15d7b064de106a739551da5f', got %q", sc.Address)
+	}
+	if len(sc.Params) != 1 {
+		t.Fatalf("expected 1 param, got %d", len(sc.Params))
+	}
+	if sc.Params[0].Name != "balance" {
+		t.Errorf("expected param name 'balance', got %q", sc.Params[0].Name)
+	}
+	if !sc.Params[0].Change {
+		t.Error("expected Change to be true")
+	}
+}
+
+func TestStateChangedValueCmp(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_state_changed_value_cmp")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.StateChanged) != 1 {
+		t.Fatalf("expected 1 stateChanged filter, got %d", len(req.StateChanged))
+	}
+	sc := req.StateChanged[0]
+	if len(sc.Params) != 1 {
+		t.Fatalf("expected 1 param, got %d", len(sc.Params))
+	}
+	if sc.Params[0].ValueCmp == nil {
+		t.Fatal("expected ValueCmp to be set")
+	}
+	if sc.Params[0].ValueCmp.Gte == nil {
+		t.Fatal("expected ValueCmp.Gte to be set")
+	}
+	if *sc.Params[0].ValueCmp.Gte != "0xde0b6b3a7640000" {
+		t.Errorf("expected ValueCmp.Gte '0xde0b6b3a7640000', got %q", *sc.Params[0].ValueCmp.Gte)
+	}
+}
+
+func TestStateChangedPercentageCmp(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_state_changed_percentage_cmp")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.StateChanged) != 1 {
+		t.Fatalf("expected 1 stateChanged filter, got %d", len(req.StateChanged))
+	}
+	sc := req.StateChanged[0]
+	if len(sc.Params) != 1 {
+		t.Fatalf("expected 1 param, got %d", len(sc.Params))
+	}
+	if sc.Params[0].PercentageCmp == nil {
+		t.Fatal("expected PercentageCmp to be set")
+	}
+	if sc.Params[0].PercentageCmp.Gte == nil {
+		t.Fatal("expected PercentageCmp.Gte to be set")
+	}
+	if *sc.Params[0].PercentageCmp.Gte != "0x32" {
+		t.Errorf("expected PercentageCmp.Gte '0x32', got %q", *sc.Params[0].PercentageCmp.Gte)
+	}
+}
+
+func TestStateChangedStorageSlot(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_state_changed_storage_slot")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.StateChanged) != 1 {
+		t.Fatalf("expected 1 stateChanged filter, got %d", len(req.StateChanged))
+	}
+	sc := req.StateChanged[0]
+	if len(sc.Params) != 1 {
+		t.Fatalf("expected 1 param, got %d", len(sc.Params))
+	}
+	if sc.Params[0].StorageSlotKey == nil {
+		t.Fatal("expected StorageSlotKey to be set")
+	}
+	if *sc.Params[0].StorageSlotKey != "0x0000000000000000000000000000000000000000000000000000000000000000" {
+		t.Errorf("unexpected StorageSlotKey: %q", *sc.Params[0].StorageSlotKey)
+	}
+}
+
+func TestStateChangedMatchAny(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_state_changed_match_any")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.StateChanged) != 1 {
+		t.Fatalf("expected 1 stateChanged filter, got %d", len(req.StateChanged))
+	}
+	sc := req.StateChanged[0]
+	if !sc.MatchAny {
+		t.Error("expected MatchAny to be true")
+	}
+	if sc.Address != "" {
+		t.Errorf("expected Address to be empty when MatchAny=true, got %q", sc.Address)
+	}
+}
+
+func TestStateChangedNot(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_state_changed_not")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.StateChanged) != 1 {
+		t.Fatalf("expected 1 stateChanged filter, got %d", len(req.StateChanged))
+	}
+	sc := req.StateChanged[0]
+	if !sc.Not {
+		t.Error("expected Not to be true")
+	}
+}
+
+func TestStateChangedMissingAddress(t *testing.T) {
+	_, response, ok := MustReadTrigger("trigger_state_changed_invalid_missing_address")
+	if ok {
+		t.Fatal("expected validation to fail when address is missing and matchAny is not set")
+	}
+	found := false
+	for _, e := range response.Errors {
+		if e == "test.transaction.filters.0.stateChanged.address: 'address' is required" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected address required error, got: %v", response.Errors)
+	}
+}
+
+func TestStateChangedParamMissingName(t *testing.T) {
+	_, response, ok := MustReadTrigger("trigger_state_changed_invalid_param_no_name")
+	if ok {
+		t.Fatal("expected validation to fail when param name is missing")
+	}
+	found := false
+	for _, e := range response.Errors {
+		if e == "test.transaction.filters.0.stateChanged.params.0: 'name' is required for parameter condition" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected param name required error, got: %v", response.Errors)
+	}
+}
+
+func TestStateChangedParamNoCondition(t *testing.T) {
+	_, response, ok := MustReadTrigger("trigger_state_changed_invalid_param_no_condition")
+	if ok {
+		t.Fatal("expected validation to fail when param has no condition")
+	}
+	found := false
+	for _, e := range response.Errors {
+		if e == "test.transaction.filters.0.stateChanged.params.0: at least one of 'change', 'valueCmp', 'percentageCmp', 'storageSlotKey' is required" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected param condition required error, got: %v", response.Errors)
+	}
+}
+
+func TestStateChangedMultiParams(t *testing.T) {
+	trigger := MustReadTriggerAndValidate("trigger_state_changed_multi_params")
+	req := trigger.Transaction.Filters[0].ToRequest()
+
+	if len(req.StateChanged) != 1 {
+		t.Fatalf("expected 1 stateChanged filter, got %d", len(req.StateChanged))
+	}
+	sc := req.StateChanged[0]
+	if len(sc.Params) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(sc.Params))
+	}
+	if sc.Params[0].Name != "balance" {
+		t.Errorf("expected first param name 'balance', got %q", sc.Params[0].Name)
+	}
+	if !sc.Params[0].Change {
+		t.Error("expected first param Change to be true")
+	}
+	if sc.Params[1].Name != "totalSupply" {
+		t.Errorf("expected second param name 'totalSupply', got %q", sc.Params[1].Name)
+	}
+	if sc.Params[1].ValueCmp == nil {
+		t.Fatal("expected second param ValueCmp to be set")
+	}
+	if sc.Params[1].ValueCmp.Gte == nil {
+		t.Fatal("expected second param ValueCmp.Gte to be set")
+	}
+	if *sc.Params[1].ValueCmp.Gte != "0x3e8" {
+		t.Errorf("expected ValueCmp.Gte '0x3e8', got %q", *sc.Params[1].ValueCmp.Gte)
+	}
+}

--- a/model/actions/trigger_state_changed_test.go
+++ b/model/actions/trigger_state_changed_test.go
@@ -43,8 +43,8 @@ func TestStateChangedValueCmp(t *testing.T) {
 	if sc.Params[0].ValueCmp.Gte == nil {
 		t.Fatal("expected ValueCmp.Gte to be set")
 	}
-	if *sc.Params[0].ValueCmp.Gte != "0xde0b6b3a7640000" {
-		t.Errorf("expected ValueCmp.Gte '0xde0b6b3a7640000', got %q", *sc.Params[0].ValueCmp.Gte)
+	if *sc.Params[0].ValueCmp.Gte != "1000000000000000000" {
+		t.Errorf("expected ValueCmp.Gte '1000000000000000000', got %q", *sc.Params[0].ValueCmp.Gte)
 	}
 }
 
@@ -65,8 +65,8 @@ func TestStateChangedPercentageCmp(t *testing.T) {
 	if sc.Params[0].PercentageCmp.Gte == nil {
 		t.Fatal("expected PercentageCmp.Gte to be set")
 	}
-	if *sc.Params[0].PercentageCmp.Gte != "0x32" {
-		t.Errorf("expected PercentageCmp.Gte '0x32', got %q", *sc.Params[0].PercentageCmp.Gte)
+	if *sc.Params[0].PercentageCmp.Gte != "50" {
+		t.Errorf("expected PercentageCmp.Gte '50', got %q", *sc.Params[0].PercentageCmp.Gte)
 	}
 }
 
@@ -192,7 +192,7 @@ func TestStateChangedMultiParams(t *testing.T) {
 	if sc.Params[1].ValueCmp.Gte == nil {
 		t.Fatal("expected second param ValueCmp.Gte to be set")
 	}
-	if *sc.Params[1].ValueCmp.Gte != "0x3e8" {
-		t.Errorf("expected ValueCmp.Gte '0x3e8', got %q", *sc.Params[1].ValueCmp.Gte)
+	if *sc.Params[1].ValueCmp.Gte != "1000" {
+		t.Errorf("expected ValueCmp.Gte '1000', got %q", *sc.Params[1].ValueCmp.Gte)
 	}
 }

--- a/model/actions/trigger_transaction.go
+++ b/model/actions/trigger_transaction.go
@@ -83,9 +83,6 @@ func parseBigIntString(s string) (*big.Int, error) {
 			return nil, errors.New("invalid decimal integer")
 		}
 	}
-	if n.Sign() < 0 {
-		return nil, errors.New("value must be non-negative")
-	}
 	return n, nil
 }
 

--- a/model/actions/trigger_transaction.go
+++ b/model/actions/trigger_transaction.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/tenderly/tenderly-cli/rest/payloads/generated/actions"
 )
@@ -114,7 +113,7 @@ func (b *BigIntValue) Validate(ctx ValidatorContext) (response ValidateResponse)
 }
 
 func (b *BigIntValue) ToRequest() actions.ComparableBigInt {
-	toHex := func(s *string) *string {
+	toDec := func(s *string) *string {
 		if s == nil {
 			return nil
 		}
@@ -122,15 +121,15 @@ func (b *BigIntValue) ToRequest() actions.ComparableBigInt {
 		if err != nil {
 			panic("BigIntValue.ToRequest called with unvalidated input: " + *s)
 		}
-		h := hexutil.EncodeBig(n)
-		return &h
+		d := n.String()
+		return &d
 	}
 	return actions.ComparableBigInt{
-		Gte: toHex(b.GTE),
-		Lte: toHex(b.LTE),
-		Eq:  toHex(b.EQ),
-		Gt:  toHex(b.GT),
-		Lt:  toHex(b.LT),
+		Gte: toDec(b.GTE),
+		Lte: toDec(b.LTE),
+		Eq:  toDec(b.EQ),
+		Gt:  toDec(b.GT),
+		Lt:  toDec(b.LT),
 		Not: b.Not,
 	}
 }

--- a/model/actions/trigger_transaction.go
+++ b/model/actions/trigger_transaction.go
@@ -2,20 +2,14 @@ package actions
 
 import (
 	"encoding/json"
+	"math/big"
 	"strconv"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/tenderly/tenderly-cli/rest/payloads/generated/actions"
 )
-
-type AccountValue struct {
-	Address AddressValue `yaml:"address" json:"address"`
-}
-
-func (a *AccountValue) Validate(ctx ValidatorContext) (response ValidateResponse) {
-	return response.Merge(a.Address.Validate(ctx.With("address")))
-}
 
 type ContractValue struct {
 	Address    AddressValue `yaml:"address" json:"address"`
@@ -68,41 +62,100 @@ func (c *ContractValue) Validate(ctx ValidatorContext) (response ValidateRespons
 	return response
 }
 
+type BigIntValue struct {
+	GTE *string `yaml:"gte" json:"gte,omitempty"`
+	LTE *string `yaml:"lte" json:"lte,omitempty"`
+	EQ  *string `yaml:"eq" json:"eq,omitempty"`
+	GT  *string `yaml:"gt" json:"gt,omitempty"`
+	LT  *string `yaml:"lt" json:"lt,omitempty"`
+	Not bool    `yaml:"not" json:"not,omitempty"`
+}
+
+func parseBigIntString(s string) (*big.Int, error) {
+	n := new(big.Int)
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		_, ok := n.SetString(s[2:], 16)
+		if !ok {
+			return nil, errors.New("invalid hex integer")
+		}
+	} else {
+		_, ok := n.SetString(s, 10)
+		if !ok {
+			return nil, errors.New("invalid decimal integer")
+		}
+	}
+	if n.Sign() < 0 {
+		return nil, errors.New("value must be non-negative")
+	}
+	return n, nil
+}
+
+func (b *BigIntValue) Validate(ctx ValidatorContext) (response ValidateResponse) {
+	if b.GTE == nil && b.LTE == nil && b.EQ == nil && b.GT == nil && b.LT == nil {
+		return response.Error(ctx, MsgBigIntNoConditionSet)
+	}
+	for _, pair := range []struct {
+		field string
+		val   *string
+	}{
+		{"gte", b.GTE},
+		{"lte", b.LTE},
+		{"eq", b.EQ},
+		{"gt", b.GT},
+		{"lt", b.LT},
+	} {
+		if pair.val != nil {
+			if _, err := parseBigIntString(*pair.val); err != nil {
+				response.Error(ctx.With(pair.field), MsgBigIntValueInvalid, *pair.val)
+			}
+		}
+	}
+	return response
+}
+
+func (b *BigIntValue) ToRequest() actions.ComparableBigInt {
+	toHex := func(s *string) *string {
+		if s == nil {
+			return nil
+		}
+		n, err := parseBigIntString(*s)
+		if err != nil {
+			panic("BigIntValue.ToRequest called with unvalidated input: " + *s)
+		}
+		h := hexutil.EncodeBig(n)
+		return &h
+	}
+	return actions.ComparableBigInt{
+		Gte: toHex(b.GTE),
+		Lte: toHex(b.LTE),
+		Eq:  toHex(b.EQ),
+		Gt:  toHex(b.GT),
+		Lt:  toHex(b.LT),
+		Not: b.Not,
+	}
+}
+
 type EthBalanceValue struct {
-	Value IntValue `yaml:"value" json:"value"`
-	// Exactly one of
-	Account  *AccountValue  `yaml:"account" json:"account"`
-	Contract *ContractValue `yaml:"contract" json:"contract"`
+	Address    *AddressValue `yaml:"address" json:"address"`
+	BalanceCmp BigIntValue   `yaml:"balanceCmp" json:"balanceCmp"`
+	Not        bool          `yaml:"not" json:"not,omitempty"`
 }
 
 func (e *EthBalanceValue) ToRequest() actions.EthBalanceFilter {
-	if e.Account != nil {
-		return actions.EthBalanceFilter{
-			Account: actions.AccountReference{Address: e.Account.Address.String()},
-			Value:   e.Value.ToRequest(),
-		}
+	return actions.EthBalanceFilter{
+		Address:    e.Address.String(),
+		BalanceCmp: e.BalanceCmp.ToRequest(),
+		Not:        e.Not,
 	}
-	if e.Contract != nil {
-		return actions.EthBalanceFilter{
-			Account: actions.AccountReference{Address: e.Contract.Address.String()},
-			Value:   e.Value.ToRequest(),
-		}
-	}
-	panic("unhandled case in ethBalance field")
 }
 
 func (e *EthBalanceValue) Validate(ctx ValidatorContext) (response ValidateResponse) {
-	if e.Account == nil && e.Contract == nil {
-		return response.Error(ctx, MsgAccountOrContractRequired)
-	}
-	if e.Account != nil && e.Contract != nil {
-		response.Error(ctx, MsgAccountAndContractForbidden)
-	}
-	if e.Account != nil {
-		response.Merge(e.Account.Validate(ctx.With("account")))
+	if e.Address == nil {
+		response.Error(ctx.With("address"), MsgAddressRequired)
 	} else {
-		response.Merge(e.Contract.Validate(ctx.With("contract")))
+		response.Merge(e.Address.Validate(ctx.With("address")))
 	}
+	response.Merge(e.BalanceCmp.Validate(ctx.With("balanceCmp")))
 	return response
 }
 
@@ -118,16 +171,14 @@ func (e *EthBalanceField) ToRequest() (response []actions.EthBalanceFilter) {
 }
 
 func (e *EthBalanceField) Validate(ctx ValidatorContext) (response ValidateResponse) {
-	return response.Error(ctx, "EthBalance filter not yet supported")
-
-	// for i, value := range e.Values {
-	// 	nextCtx := ctx
-	// 	if len(e.Values) > 1 {
-	// 		nextCtx = ctx.With(strconv.Itoa(i))
-	// 	}
-	// 	response.Merge(value.Validate(nextCtx))
-	// }
-	// return response
+	for i, value := range e.Values {
+		nextCtx := ctx
+		if len(e.Values) > 1 {
+			nextCtx = ctx.With(strconv.Itoa(i))
+		}
+		response.Merge(value.Validate(nextCtx))
+	}
+	return response
 }
 
 func (e *EthBalanceField) UnmarshalJSON(bytes []byte) error {
@@ -478,71 +529,79 @@ func (l *LogEmittedField) ToRequest() (response []actions.LogEmittedFilter) {
 	return response
 }
 
+type StateChangedParamCondValue struct {
+	Name           string       `yaml:"name" json:"name"`
+	Change         bool         `yaml:"change" json:"change,omitempty"`
+	ValueCmp       *BigIntValue `yaml:"valueCmp" json:"valueCmp,omitempty"`
+	PercentageCmp  *BigIntValue `yaml:"percentageCmp" json:"percentageCmp,omitempty"`
+	StorageSlotKey *string      `yaml:"storageSlotKey" json:"storageSlotKey,omitempty"`
+}
+
+func (p *StateChangedParamCondValue) Validate(ctx ValidatorContext) (response ValidateResponse) {
+	if strings.TrimSpace(p.Name) == "" {
+		response.Error(ctx, MsgParamNameRequired)
+	}
+	if !p.Change && p.ValueCmp == nil && p.PercentageCmp == nil && p.StorageSlotKey == nil {
+		response.Error(ctx, MsgStateChangedParamConditionRequired)
+	}
+	if p.ValueCmp != nil {
+		response.Merge(p.ValueCmp.Validate(ctx.With("valueCmp")))
+	}
+	if p.PercentageCmp != nil {
+		response.Merge(p.PercentageCmp.Validate(ctx.With("percentageCmp")))
+	}
+	return response
+}
+
+func (p *StateChangedParamCondValue) ToRequest() actions.StateChangedParamCondition {
+	cond := actions.StateChangedParamCondition{
+		Name:           p.Name,
+		Change:         p.Change,
+		StorageSlotKey: p.StorageSlotKey,
+	}
+	if p.ValueCmp != nil {
+		cmp := p.ValueCmp.ToRequest()
+		cond.ValueCmp = &cmp
+	}
+	if p.PercentageCmp != nil {
+		cmp := p.PercentageCmp.ToRequest()
+		cond.PercentageCmp = &cmp
+	}
+	return cond
+}
+
 type StateChangedValue struct {
-	Contract *ContractValue `yaml:"contract" json:"contract"`
-	// Exactly one of
-	Key   *string `yaml:"key" json:"key"`
-	Field *string `yaml:"field" json:"field"`
-	// At most one of, only with Field
-	// If none, any state changed at given key is considered
-	Value         *AnyValue `yaml:"value" json:"value"`
-	PreviousValue *AnyValue `yaml:"previousValue" json:"previousValue"`
+	Address  *AddressValue                `yaml:"address" json:"address"`
+	MatchAny bool                         `yaml:"matchAny" json:"matchAny,omitempty"`
+	Params   []StateChangedParamCondValue `yaml:"params" json:"params,omitempty"`
+	Not      bool                         `yaml:"not" json:"not,omitempty"`
 }
 
 func (r *StateChangedValue) ToRequest() actions.StateChangedFilter {
-	if r.Key != nil {
-		return actions.StateChangedFilter{
-			Contract: r.Contract.ToRequest(),
-			Key:      r.Key,
-		}
+	filter := actions.StateChangedFilter{
+		MatchAny: r.MatchAny,
+		Not:      r.Not,
 	}
-	if r.Field != nil {
-		var value *actions.ComparableAny
-		if r.Value != nil {
-			val := r.Value.ToRequest()
-			value = &val
-		}
-		var previousValue *actions.ComparableAny
-		if r.PreviousValue != nil {
-			val := r.PreviousValue.ToRequest()
-			previousValue = &val
-		}
-		return actions.StateChangedFilter{
-			Contract:      r.Contract.ToRequest(),
-			Field:         r.Field,
-			Value:         value,
-			PreviousValue: previousValue,
-		}
+	if r.Address != nil {
+		filter.Address = r.Address.String()
 	}
-	panic("unhandled case in function field")
+	for _, p := range r.Params {
+		filter.Params = append(filter.Params, p.ToRequest())
+	}
+	return filter
 }
 
 func (r *StateChangedValue) Validate(ctx ValidatorContext) (response ValidateResponse) {
-	// Modify
-	if r.Key != nil {
-		key := strings.ToLower(strings.TrimSpace(*r.Key))
-		r.Key = &key
+	if !r.MatchAny {
+		if r.Address == nil {
+			response.Error(ctx.With("address"), MsgAddressRequired)
+		} else {
+			response.Merge(r.Address.Validate(ctx.With("address")))
+		}
 	}
-
-	if r.Contract == nil {
-		response.Error(ctx, MsgContractRequired)
-	} else {
-		response.Merge(r.Contract.Validate(ctx.With("contract")))
+	for i, p := range r.Params {
+		response.Merge(p.Validate(ctx.With("params").With(strconv.Itoa(i))))
 	}
-
-	if r.Key == nil && r.Field == nil {
-		response.Error(ctx, MsgKeyOrFieldRequired)
-	}
-	if r.Key != nil && r.Field != nil {
-		response.Error(ctx, MsgKeyAndFieldForbidden)
-	}
-	if r.Key != nil && (r.Value != nil || r.PreviousValue != nil) {
-		response.Error(ctx, MsgKeyAndValueOrPreviousValueForbidden)
-	}
-	if r.Value != nil && r.PreviousValue != nil {
-		response.Error(ctx, MsgValueAndPreviousValueForbidden)
-	}
-
 	return response
 }
 
@@ -551,16 +610,14 @@ type StateChangedField struct {
 }
 
 func (s *StateChangedField) Validate(ctx ValidatorContext) (response ValidateResponse) {
-	return response.Error(ctx, "StateChanged filter not yet supported")
-
-	// for i, value := range s.Values {
-	// 	nextCtx := ctx
-	// 	if len(s.Values) > 1 {
-	// 		nextCtx = ctx.With(strconv.Itoa(i))
-	// 	}
-	// 	response.Merge(value.Validate(nextCtx))
-	// }
-	// return response
+	for i, value := range s.Values {
+		nextCtx := ctx
+		if len(s.Values) > 1 {
+			nextCtx = ctx.With(strconv.Itoa(i))
+		}
+		response.Merge(value.Validate(nextCtx))
+	}
+	return response
 }
 
 func (s *StateChangedField) UnmarshalJSON(bytes []byte) error {
@@ -647,14 +704,12 @@ func (t *TransactionFilter) ToRequest() (response actions.Filter) {
 	if t.LogEmitted != nil {
 		response.LogEmmitted = t.LogEmitted.ToRequest()
 	}
-
-	// TODO(marko): Support eth balance and state changed
-	// if t.EthBalance != nil {
-	// 	response.EthBalance = t.EthBalance.ToRequest()
-	// }
-	// if t.StateChanged != nil {
-	// 	response.StateChanged = t.StateChanged.ToRequest()
-	// }
+	if t.EthBalance != nil {
+		response.EthBalance = t.EthBalance.ToRequest()
+	}
+	if t.StateChanged != nil {
+		response.StateChanged = t.StateChanged.ToRequest()
+	}
 
 	return response
 }
@@ -665,13 +720,6 @@ func (t *TransactionFilter) Validate(ctx ValidatorContext) (response ValidateRes
 
 	// Set top level contract on nested fields
 	if t.Contract != nil {
-		if t.EthBalance != nil {
-			for i := 0; i < len(t.EthBalance.Values); i++ {
-				if t.EthBalance.Values[i].Account == nil && t.EthBalance.Values[i].Contract == nil {
-					t.EthBalance.Values[i].Contract = t.Contract
-				}
-			}
-		}
 		if t.Function != nil {
 			for i := 0; i < len(t.Function.Values); i++ {
 				if t.Function.Values[i].Contract == nil {
@@ -683,13 +731,6 @@ func (t *TransactionFilter) Validate(ctx ValidatorContext) (response ValidateRes
 			for i := 0; i < len(t.EventEmitted.Values); i++ {
 				if t.EventEmitted.Values[i].Contract == nil {
 					t.EventEmitted.Values[i].Contract = t.Contract
-				}
-			}
-		}
-		if t.StateChanged != nil {
-			for i := 0; i < len(t.StateChanged.Values); i++ {
-				if t.StateChanged.Values[i].Contract == nil {
-					t.StateChanged.Values[i].Contract = t.Contract
 				}
 			}
 		}
@@ -735,7 +776,9 @@ func (t *TransactionFilter) isMinFilterConstraintFulfilled() bool {
 		(t.To != nil && len(t.To.Values) > 0) ||
 		(t.Function != nil && len(t.Function.Values) > 0) ||
 		(t.EventEmitted != nil && len(t.EventEmitted.Values) > 0) ||
-		(t.LogEmitted != nil && len(t.LogEmitted.Values) > 0)
+		(t.LogEmitted != nil && len(t.LogEmitted.Values) > 0) ||
+		(t.EthBalance != nil && len(t.EthBalance.Values) > 0) ||
+		(t.StateChanged != nil && len(t.StateChanged.Values) > 0)
 }
 
 type TransactionTrigger struct {

--- a/model/actions/util_test.go
+++ b/model/actions/util_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"testing"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -53,4 +54,14 @@ func MustReadTriggerAndFailValidate(filename string) actions.Trigger {
 		panic("trigger validation did not fail but expected")
 	}
 	return trigger
+}
+
+func requireValidationError(t *testing.T, response actions.ValidateResponse, expected string) {
+	t.Helper()
+	for _, e := range response.Errors {
+		if e == expected {
+			return
+		}
+	}
+	t.Errorf("expected error %q, got: %v", expected, response.Errors)
 }

--- a/model/actions/yaml/trigger_eth_balance.yaml
+++ b/model/actions/yaml/trigger_eth_balance.yaml
@@ -1,0 +1,10 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        balanceCmp:
+          gte: "1000000000000000000"

--- a/model/actions/yaml/trigger_eth_balance_eq.yaml
+++ b/model/actions/yaml/trigger_eth_balance_eq.yaml
@@ -1,0 +1,10 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        balanceCmp:
+          eq: "1000000000000000000"

--- a/model/actions/yaml/trigger_eth_balance_hex.yaml
+++ b/model/actions/yaml/trigger_eth_balance_hex.yaml
@@ -1,0 +1,10 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        balanceCmp:
+          gte: "0x0de0b6b3a7640000"

--- a/model/actions/yaml/trigger_eth_balance_invalid_bad_hex.yaml
+++ b/model/actions/yaml/trigger_eth_balance_invalid_bad_hex.yaml
@@ -1,0 +1,10 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        balanceCmp:
+          gte: "0xZZZ"

--- a/model/actions/yaml/trigger_eth_balance_invalid_missing_address.yaml
+++ b/model/actions/yaml/trigger_eth_balance_invalid_missing_address.yaml
@@ -1,0 +1,9 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        balanceCmp:
+          gte: "1000000000000000000"

--- a/model/actions/yaml/trigger_eth_balance_invalid_negative.yaml
+++ b/model/actions/yaml/trigger_eth_balance_invalid_negative.yaml
@@ -1,0 +1,10 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        balanceCmp:
+          gte: "-1"

--- a/model/actions/yaml/trigger_eth_balance_invalid_no_cmp.yaml
+++ b/model/actions/yaml/trigger_eth_balance_invalid_no_cmp.yaml
@@ -1,0 +1,9 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        balanceCmp: {}

--- a/model/actions/yaml/trigger_eth_balance_multi.yaml
+++ b/model/actions/yaml/trigger_eth_balance_multi.yaml
@@ -1,0 +1,13 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        - address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+          balanceCmp:
+            gte: "1000000000000000000"
+        - address: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+          balanceCmp:
+            lte: "500000000000000000"

--- a/model/actions/yaml/trigger_eth_balance_not.yaml
+++ b/model/actions/yaml/trigger_eth_balance_not.yaml
@@ -1,0 +1,11 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        balanceCmp:
+          lte: "500000000000000000"
+        not: true

--- a/model/actions/yaml/trigger_eth_balance_range.yaml
+++ b/model/actions/yaml/trigger_eth_balance_range.yaml
@@ -1,0 +1,11 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      ethBalance:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        balanceCmp:
+          gte: "1000000000000000000"
+          lte: "2000000000000000000"

--- a/model/actions/yaml/trigger_state_changed_change.yaml
+++ b/model/actions/yaml/trigger_state_changed_change.yaml
@@ -1,0 +1,11 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        params:
+          - name: balance
+            change: true

--- a/model/actions/yaml/trigger_state_changed_invalid_missing_address.yaml
+++ b/model/actions/yaml/trigger_state_changed_invalid_missing_address.yaml
@@ -1,0 +1,10 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        params:
+          - name: balance
+            change: true

--- a/model/actions/yaml/trigger_state_changed_invalid_param_no_condition.yaml
+++ b/model/actions/yaml/trigger_state_changed_invalid_param_no_condition.yaml
@@ -1,0 +1,10 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        params:
+          - name: balance

--- a/model/actions/yaml/trigger_state_changed_invalid_param_no_name.yaml
+++ b/model/actions/yaml/trigger_state_changed_invalid_param_no_name.yaml
@@ -1,0 +1,10 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        params:
+          - change: true

--- a/model/actions/yaml/trigger_state_changed_match_any.yaml
+++ b/model/actions/yaml/trigger_state_changed_match_any.yaml
@@ -1,0 +1,11 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        matchAny: true
+        params:
+          - name: balance
+            change: true

--- a/model/actions/yaml/trigger_state_changed_multi_params.yaml
+++ b/model/actions/yaml/trigger_state_changed_multi_params.yaml
@@ -1,0 +1,14 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        params:
+          - name: balance
+            change: true
+          - name: totalSupply
+            valueCmp:
+              gte: "1000"

--- a/model/actions/yaml/trigger_state_changed_not.yaml
+++ b/model/actions/yaml/trigger_state_changed_not.yaml
@@ -1,0 +1,12 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        params:
+          - name: balance
+            change: true
+        not: true

--- a/model/actions/yaml/trigger_state_changed_percentage_cmp.yaml
+++ b/model/actions/yaml/trigger_state_changed_percentage_cmp.yaml
@@ -1,0 +1,12 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        params:
+          - name: balance
+            percentageCmp:
+              gte: "50"

--- a/model/actions/yaml/trigger_state_changed_storage_slot.yaml
+++ b/model/actions/yaml/trigger_state_changed_storage_slot.yaml
@@ -1,0 +1,11 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        params:
+          - name: slot0
+            storageSlotKey: "0x0000000000000000000000000000000000000000000000000000000000000000"

--- a/model/actions/yaml/trigger_state_changed_value_cmp.yaml
+++ b/model/actions/yaml/trigger_state_changed_value_cmp.yaml
@@ -1,0 +1,12 @@
+type: transaction
+transaction:
+  status:
+    - mined
+  filters:
+    - network: "1"
+      stateChanged:
+        address: "0x13253c152f4d724d15d7b064de106a739551da5f"
+        params:
+          - name: balance
+            valueCmp:
+              gte: "1000000000000000000"

--- a/rest/payloads/generated/actions/structs.conjure.go
+++ b/rest/payloads/generated/actions/structs.conjure.go
@@ -1207,7 +1207,7 @@ func (o *SecretsPayload) UnmarshalYAML(unmarshal func(interface{}) error) error 
 }
 
 type StateChangedFilter struct {
-	Address  string                       `json:"address,omitempty"`
+	Address  string                       `json:"address"`
 	MatchAny bool                         `json:"matchAny,omitempty"`
 	Params   []StateChangedParamCondition `json:"params,omitempty"`
 	Not      bool                         `json:"not,omitempty"`

--- a/rest/payloads/generated/actions/structs.conjure.go
+++ b/rest/payloads/generated/actions/structs.conjure.go
@@ -8,26 +8,6 @@ import (
 	"github.com/palantir/pkg/safeyaml"
 )
 
-type AccountReference struct {
-	Address string `json:"address"`
-}
-
-func (o AccountReference) MarshalYAML() (interface{}, error) {
-	jsonBytes, err := safejson.Marshal(o)
-	if err != nil {
-		return nil, err
-	}
-	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
-}
-
-func (o *AccountReference) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
-	if err != nil {
-		return err
-	}
-	return safejson.Unmarshal(jsonBytes, *&o)
-}
-
 type Action struct {
 	Id          string       `json:"id"`
 	ProjectId   string       `json:"projectId"`
@@ -678,9 +658,27 @@ func (o *DeployResponse) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	return safejson.Unmarshal(jsonBytes, *&o)
 }
 
+type ComparableBigInt struct {
+	Gte *string `json:"gte,omitempty"`
+	Lte *string `json:"lte,omitempty"`
+	Eq  *string `json:"eq,omitempty"`
+	Gt  *string `json:"gt,omitempty"`
+	Lt  *string `json:"lt,omitempty"`
+	Not bool    `json:"not,omitempty"`
+}
+
+type StateChangedParamCondition struct {
+	Name           string            `json:"name"`
+	Change         bool              `json:"change,omitempty"`
+	ValueCmp       *ComparableBigInt `json:"valueCmp,omitempty"`
+	PercentageCmp  *ComparableBigInt `json:"percentageCmp,omitempty"`
+	StorageSlotKey *string           `json:"storageSlotKey,omitempty"`
+}
+
 type EthBalanceFilter struct {
-	Account AccountReference `json:"account"`
-	Value   ComparableInt    `json:"value"`
+	Address    string           `json:"address"`
+	BalanceCmp ComparableBigInt `json:"balanceCmp"`
+	Not        bool             `json:"not,omitempty"`
 }
 
 func (o EthBalanceFilter) MarshalYAML() (interface{}, error) {
@@ -764,6 +762,8 @@ type Filter struct {
 	Function     []FunctionFilter     `json:"function"`
 	EventEmitted []EventEmittedFilter `json:"eventEmitted"`
 	LogEmmitted  []LogEmittedFilter   `json:"logEmmitted"`
+	EthBalance   []EthBalanceFilter   `json:"ethBalance"`
+	StateChanged []StateChangedFilter `json:"stateChanged"`
 }
 
 func (o Filter) MarshalJSON() ([]byte, error) {
@@ -799,6 +799,12 @@ func (o Filter) MarshalJSON() ([]byte, error) {
 	}
 	if o.LogEmmitted == nil {
 		o.LogEmmitted = make([]LogEmittedFilter, 0)
+	}
+	if o.EthBalance == nil {
+		o.EthBalance = make([]EthBalanceFilter, 0)
+	}
+	if o.StateChanged == nil {
+		o.StateChanged = make([]StateChangedFilter, 0)
 	}
 	type FilterAlias Filter
 	return safejson.Marshal(FilterAlias(o))
@@ -842,6 +848,12 @@ func (o *Filter) UnmarshalJSON(data []byte) error {
 	}
 	if rawFilter.LogEmmitted == nil {
 		rawFilter.LogEmmitted = make([]LogEmittedFilter, 0)
+	}
+	if rawFilter.EthBalance == nil {
+		rawFilter.EthBalance = make([]EthBalanceFilter, 0)
+	}
+	if rawFilter.StateChanged == nil {
+		rawFilter.StateChanged = make([]StateChangedFilter, 0)
 	}
 	*o = Filter(rawFilter)
 	return nil
@@ -1195,11 +1207,10 @@ func (o *SecretsPayload) UnmarshalYAML(unmarshal func(interface{}) error) error 
 }
 
 type StateChangedFilter struct {
-	Contract      ContractReference `json:"contract"`
-	Key           *string           `json:"key"`
-	Field         *string           `json:"field"`
-	Value         *ComparableAny    `json:"value"`
-	PreviousValue *ComparableAny    `json:"previousValue"`
+	Address  string                       `json:"address,omitempty"`
+	MatchAny bool                         `json:"matchAny,omitempty"`
+	Params   []StateChangedParamCondition `json:"params,omitempty"`
+	Not      bool                         `json:"not,omitempty"`
 }
 
 func (o StateChangedFilter) MarshalYAML() (interface{}, error) {


### PR DESCRIPTION
## Summary
- Add `ethBalance` and `stateChanged` as new transaction filter types in the JSON schema and runtime validation
- New types: `BigIntValue` (decimal/hex input, decimal wire format), `EthBalanceValue` (address + balance comparison), `StateChangedValue` (address/matchAny + param conditions with change/valueCmp/percentageCmp/storageSlotKey)
- Expose `transaction_filter_types` in capabilities output for agent/tooling discovery
- Clean up review nits: remove dead `AccountReference` type, fix const alignment, simplify redundant `ToRequest()` guard
- Fix BigInt serialization: output decimal strings to match backend's `ethtype.BigInt.UnmarshalJSON` (base 10 only)

## Test plan
- [x] All tests pass (`go test ./model/actions/... ./commands/actions/...`)
- [x] `go vet` clean
- [x] Cross-referenced with `actions-trigger-service` in tenderly-core — all struct fields, JSON tags, and serialization formats match
- [x] Test coverage: all BigInt operators (gte/lte/eq/gt/lt), multi-item arrays, invalid hex, negative values, schema validation of new defs
- [x] 22 YAML test fixtures covering valid and invalid cases for both trigger types